### PR TITLE
Switch SEO metadata to documate.work

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -6,49 +6,49 @@
   <meta name="robots" content="index,follow" />
 
   <!-- Google Search Console -->
-  <meta name="google-site-verification" content="yHzn771ZljIbFj8wJJlnJ2FVIw9YjW1w0EJlZImH0QA" />
+  <meta name="google-site-verification" content="NOUVEAU_TOKEN_DOCUMATE_WORK" />
 
   <!-- AdSense global (keep once per page) -->
   <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9411950027978678" crossorigin="anonymous"></script>
 
   <title id="meta-title">DocuMate — Understand your documents easily</title>
   <meta id="meta-desc" name="description" content="DocuMate explains contracts, bills and official documents in plain language. Free, private, multilingual.">
-  <link id="link-canonical" rel="canonical" href="https://documate-pi.vercel.app/" />
+  <link id="link-canonical" rel="canonical" href="https://documate.work/ar/" />
 
   <!-- Hreflang (static full set) -->
-  <link rel="alternate" hreflang="x-default" href="https://documate-pi.vercel.app/">
-  <link rel="alternate" hreflang="en" href="https://documate-pi.vercel.app/">
-  <link rel="alternate" hreflang="fr" href="https://documate-pi.vercel.app/fr/">
-  <link rel="alternate" hreflang="de" href="https://documate-pi.vercel.app/de/">
-  <link rel="alternate" hreflang="es" href="https://documate-pi.vercel.app/es/">
-  <link rel="alternate" hreflang="it" href="https://documate-pi.vercel.app/it/">
-  <link rel="alternate" hreflang="zh" href="https://documate-pi.vercel.app/zh/">
-  <link rel="alternate" hreflang="hi" href="https://documate-pi.vercel.app/hi/">
-  <link rel="alternate" hreflang="ar" href="https://documate-pi.vercel.app/ar/">
-  <link rel="alternate" hreflang="pt" href="https://documate-pi.vercel.app/pt/">
-  <link rel="alternate" hreflang="ru" href="https://documate-pi.vercel.app/ru/">
-  <link rel="alternate" hreflang="bn" href="https://documate-pi.vercel.app/bn/">
+  <link rel="alternate" hreflang="x-default" href="https://documate.work/">
+  <link rel="alternate" hreflang="en" href="https://documate.work/">
+  <link rel="alternate" hreflang="fr" href="https://documate.work/fr/">
+  <link rel="alternate" hreflang="de" href="https://documate.work/de/">
+  <link rel="alternate" hreflang="es" href="https://documate.work/es/">
+  <link rel="alternate" hreflang="it" href="https://documate.work/it/">
+  <link rel="alternate" hreflang="zh" href="https://documate.work/zh/">
+  <link rel="alternate" hreflang="hi" href="https://documate.work/hi/">
+  <link rel="alternate" hreflang="ar" href="https://documate.work/ar/">
+  <link rel="alternate" hreflang="pt" href="https://documate.work/pt/">
+  <link rel="alternate" hreflang="ru" href="https://documate.work/ru/">
+  <link rel="alternate" hreflang="bn" href="https://documate.work/bn/">
 
   <!-- Open Graph / Twitter, will be rewritten by JS on load -->
   <meta property="og:type" content="website">
-  <meta id="og-url" property="og:url" content="https://documate-pi.vercel.app/">
+  <meta id="og-url" property="og:url" content="https://documate.work/ar/">
   <meta id="og-title" property="og:title" content="DocuMate — Understand your documents easily">
   <meta id="og-desc" property="og:description" content="Explain contracts, bills & official documents in plain language. Free, private, multilingual.">
-  <meta property="og:image" content="https://documate-pi.vercel.app/og.jpg">
+  <meta property="og:image" content="https://documate.work/og.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta id="tw-title" name="twitter:title" content="DocuMate — Understand your documents easily">
   <meta id="tw-desc" name="twitter:description" content="Explain contracts, bills & official documents in plain language. Free, private, multilingual.">
-  <meta name="twitter:image" content="https://documate-pi.vercel.app/og.jpg">
+  <meta name="twitter:image" content="https://documate.work/og.jpg">
 
   <!-- Favicon -->
   <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>📄</text></svg>">
 
   <!-- JSON-LD Organization (static) -->
   <script type="application/ld+json">
-  {"@context":"https://schema.org","@type":"Organization","name":"DocuMate","url":"https://documate-pi.vercel.app/","logo":"https://documate-pi.vercel.app/og.jpg"}
+  {"@context":"https://schema.org","@type":"Organization","name":"DocuMate","url":"https://documate.work/","logo":"https://documate.work/og.jpg"}
   </script>
   <!-- JSON-LD WebSite (lang is updated at runtime) -->
-  <script type="application/ld+json" id="jsonld-website">{"@context":"https://schema.org","@type":"WebSite","name":"DocuMate","url":"https://documate-pi.vercel.app/","inLanguage":"en","description":"Explain contracts, bills & official documents in plain language."}</script>
+  <script type="application/ld+json" id="jsonld-website">{"@context":"https://schema.org","@type":"WebSite","name":"DocuMate","url":"https://documate.work/","inLanguage":"en","description":"Explain contracts, bills & official documents in plain language."}</script>
 
   <!-- PDF.js & Mammoth.js (DOCX) -->
   <script src="https://unpkg.com/pdfjs-dist@4.7.76/build/pdf.min.js"></script>
@@ -289,7 +289,7 @@
       document.title = L.htmlTitle;
       $('#meta-title').textContent = L.htmlTitle;
       $('#meta-desc')?.setAttribute('content', L.htmlDesc);
-      const base = 'https://documate-pi.vercel.app';
+      const base = 'https://documate.work';
       const path = LANG_PATH[lang] || '/';
       $('#link-canonical')?.setAttribute('href', base + path);
       $('#og-url')?.setAttribute('content', base + path);
@@ -299,7 +299,7 @@
       $('#tw-desc')?.setAttribute('content', L.htmlDesc);
 
       // JSON-LD website
-      const ld = {"@context":"https://schema.org","@type":"WebSite","name":"DocuMate","url":"https://documate-pi.vercel.app/","inLanguage":lang,"description":L.htmlDesc};
+      const ld = {"@context":"https://schema.org","@type":"WebSite","name":"DocuMate","url":"https://documate.work/","inLanguage":lang,"description":L.htmlDesc};
       $('#jsonld-website').textContent = JSON.stringify(ld);
 
       // Update select value label text (keep options static)

--- a/bn/index.html
+++ b/bn/index.html
@@ -6,49 +6,49 @@
   <meta name="robots" content="index,follow" />
 
   <!-- Google Search Console -->
-  <meta name="google-site-verification" content="yHzn771ZljIbFj8wJJlnJ2FVIw9YjW1w0EJlZImH0QA" />
+  <meta name="google-site-verification" content="NOUVEAU_TOKEN_DOCUMATE_WORK" />
 
   <!-- AdSense global (keep once per page) -->
   <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9411950027978678" crossorigin="anonymous"></script>
 
   <title id="meta-title">DocuMate — Understand your documents easily</title>
   <meta id="meta-desc" name="description" content="DocuMate explains contracts, bills and official documents in plain language. Free, private, multilingual.">
-  <link id="link-canonical" rel="canonical" href="https://documate-pi.vercel.app/" />
+  <link id="link-canonical" rel="canonical" href="https://documate.work/bn/" />
 
   <!-- Hreflang (static full set) -->
-  <link rel="alternate" hreflang="x-default" href="https://documate-pi.vercel.app/">
-  <link rel="alternate" hreflang="en" href="https://documate-pi.vercel.app/">
-  <link rel="alternate" hreflang="fr" href="https://documate-pi.vercel.app/fr/">
-  <link rel="alternate" hreflang="de" href="https://documate-pi.vercel.app/de/">
-  <link rel="alternate" hreflang="es" href="https://documate-pi.vercel.app/es/">
-  <link rel="alternate" hreflang="it" href="https://documate-pi.vercel.app/it/">
-  <link rel="alternate" hreflang="zh" href="https://documate-pi.vercel.app/zh/">
-  <link rel="alternate" hreflang="hi" href="https://documate-pi.vercel.app/hi/">
-  <link rel="alternate" hreflang="ar" href="https://documate-pi.vercel.app/ar/">
-  <link rel="alternate" hreflang="pt" href="https://documate-pi.vercel.app/pt/">
-  <link rel="alternate" hreflang="ru" href="https://documate-pi.vercel.app/ru/">
-  <link rel="alternate" hreflang="bn" href="https://documate-pi.vercel.app/bn/">
+  <link rel="alternate" hreflang="x-default" href="https://documate.work/">
+  <link rel="alternate" hreflang="en" href="https://documate.work/">
+  <link rel="alternate" hreflang="fr" href="https://documate.work/fr/">
+  <link rel="alternate" hreflang="de" href="https://documate.work/de/">
+  <link rel="alternate" hreflang="es" href="https://documate.work/es/">
+  <link rel="alternate" hreflang="it" href="https://documate.work/it/">
+  <link rel="alternate" hreflang="zh" href="https://documate.work/zh/">
+  <link rel="alternate" hreflang="hi" href="https://documate.work/hi/">
+  <link rel="alternate" hreflang="ar" href="https://documate.work/ar/">
+  <link rel="alternate" hreflang="pt" href="https://documate.work/pt/">
+  <link rel="alternate" hreflang="ru" href="https://documate.work/ru/">
+  <link rel="alternate" hreflang="bn" href="https://documate.work/bn/">
 
   <!-- Open Graph / Twitter, will be rewritten by JS on load -->
   <meta property="og:type" content="website">
-  <meta id="og-url" property="og:url" content="https://documate-pi.vercel.app/">
+  <meta id="og-url" property="og:url" content="https://documate.work/bn/">
   <meta id="og-title" property="og:title" content="DocuMate — Understand your documents easily">
   <meta id="og-desc" property="og:description" content="Explain contracts, bills & official documents in plain language. Free, private, multilingual.">
-  <meta property="og:image" content="https://documate-pi.vercel.app/og.jpg">
+  <meta property="og:image" content="https://documate.work/og.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta id="tw-title" name="twitter:title" content="DocuMate — Understand your documents easily">
   <meta id="tw-desc" name="twitter:description" content="Explain contracts, bills & official documents in plain language. Free, private, multilingual.">
-  <meta name="twitter:image" content="https://documate-pi.vercel.app/og.jpg">
+  <meta name="twitter:image" content="https://documate.work/og.jpg">
 
   <!-- Favicon -->
   <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>📄</text></svg>">
 
   <!-- JSON-LD Organization (static) -->
   <script type="application/ld+json">
-  {"@context":"https://schema.org","@type":"Organization","name":"DocuMate","url":"https://documate-pi.vercel.app/","logo":"https://documate-pi.vercel.app/og.jpg"}
+  {"@context":"https://schema.org","@type":"Organization","name":"DocuMate","url":"https://documate.work/","logo":"https://documate.work/og.jpg"}
   </script>
   <!-- JSON-LD WebSite (lang is updated at runtime) -->
-  <script type="application/ld+json" id="jsonld-website">{"@context":"https://schema.org","@type":"WebSite","name":"DocuMate","url":"https://documate-pi.vercel.app/","inLanguage":"en","description":"Explain contracts, bills & official documents in plain language."}</script>
+  <script type="application/ld+json" id="jsonld-website">{"@context":"https://schema.org","@type":"WebSite","name":"DocuMate","url":"https://documate.work/","inLanguage":"en","description":"Explain contracts, bills & official documents in plain language."}</script>
 
   <!-- PDF.js & Mammoth.js (DOCX) -->
   <script src="https://unpkg.com/pdfjs-dist@4.7.76/build/pdf.min.js"></script>
@@ -289,7 +289,7 @@
       document.title = L.htmlTitle;
       $('#meta-title').textContent = L.htmlTitle;
       $('#meta-desc')?.setAttribute('content', L.htmlDesc);
-      const base = 'https://documate-pi.vercel.app';
+      const base = 'https://documate.work';
       const path = LANG_PATH[lang] || '/';
       $('#link-canonical')?.setAttribute('href', base + path);
       $('#og-url')?.setAttribute('content', base + path);
@@ -299,7 +299,7 @@
       $('#tw-desc')?.setAttribute('content', L.htmlDesc);
 
       // JSON-LD website
-      const ld = {"@context":"https://schema.org","@type":"WebSite","name":"DocuMate","url":"https://documate-pi.vercel.app/","inLanguage":lang,"description":L.htmlDesc};
+      const ld = {"@context":"https://schema.org","@type":"WebSite","name":"DocuMate","url":"https://documate.work/","inLanguage":lang,"description":L.htmlDesc};
       $('#jsonld-website').textContent = JSON.stringify(ld);
 
       // Update select value label text (keep options static)

--- a/de/index.html
+++ b/de/index.html
@@ -6,49 +6,49 @@
   <meta name="robots" content="index,follow" />
 
   <!-- Google Search Console -->
-  <meta name="google-site-verification" content="yHzn771ZljIbFj8wJJlnJ2FVIw9YjW1w0EJlZImH0QA" />
+  <meta name="google-site-verification" content="NOUVEAU_TOKEN_DOCUMATE_WORK" />
 
   <!-- AdSense global (keep once per page) -->
   <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9411950027978678" crossorigin="anonymous"></script>
 
   <title id="meta-title">DocuMate — Understand your documents easily</title>
   <meta id="meta-desc" name="description" content="DocuMate explains contracts, bills and official documents in plain language. Free, private, multilingual.">
-  <link id="link-canonical" rel="canonical" href="https://documate-pi.vercel.app/" />
+  <link id="link-canonical" rel="canonical" href="https://documate.work/de/" />
 
   <!-- Hreflang (static full set) -->
-  <link rel="alternate" hreflang="x-default" href="https://documate-pi.vercel.app/">
-  <link rel="alternate" hreflang="en" href="https://documate-pi.vercel.app/">
-  <link rel="alternate" hreflang="fr" href="https://documate-pi.vercel.app/fr/">
-  <link rel="alternate" hreflang="de" href="https://documate-pi.vercel.app/de/">
-  <link rel="alternate" hreflang="es" href="https://documate-pi.vercel.app/es/">
-  <link rel="alternate" hreflang="it" href="https://documate-pi.vercel.app/it/">
-  <link rel="alternate" hreflang="zh" href="https://documate-pi.vercel.app/zh/">
-  <link rel="alternate" hreflang="hi" href="https://documate-pi.vercel.app/hi/">
-  <link rel="alternate" hreflang="ar" href="https://documate-pi.vercel.app/ar/">
-  <link rel="alternate" hreflang="pt" href="https://documate-pi.vercel.app/pt/">
-  <link rel="alternate" hreflang="ru" href="https://documate-pi.vercel.app/ru/">
-  <link rel="alternate" hreflang="bn" href="https://documate-pi.vercel.app/bn/">
+  <link rel="alternate" hreflang="x-default" href="https://documate.work/">
+  <link rel="alternate" hreflang="en" href="https://documate.work/">
+  <link rel="alternate" hreflang="fr" href="https://documate.work/fr/">
+  <link rel="alternate" hreflang="de" href="https://documate.work/de/">
+  <link rel="alternate" hreflang="es" href="https://documate.work/es/">
+  <link rel="alternate" hreflang="it" href="https://documate.work/it/">
+  <link rel="alternate" hreflang="zh" href="https://documate.work/zh/">
+  <link rel="alternate" hreflang="hi" href="https://documate.work/hi/">
+  <link rel="alternate" hreflang="ar" href="https://documate.work/ar/">
+  <link rel="alternate" hreflang="pt" href="https://documate.work/pt/">
+  <link rel="alternate" hreflang="ru" href="https://documate.work/ru/">
+  <link rel="alternate" hreflang="bn" href="https://documate.work/bn/">
 
   <!-- Open Graph / Twitter, will be rewritten by JS on load -->
   <meta property="og:type" content="website">
-  <meta id="og-url" property="og:url" content="https://documate-pi.vercel.app/">
+  <meta id="og-url" property="og:url" content="https://documate.work/de/">
   <meta id="og-title" property="og:title" content="DocuMate — Understand your documents easily">
   <meta id="og-desc" property="og:description" content="Explain contracts, bills & official documents in plain language. Free, private, multilingual.">
-  <meta property="og:image" content="https://documate-pi.vercel.app/og.jpg">
+  <meta property="og:image" content="https://documate.work/og.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta id="tw-title" name="twitter:title" content="DocuMate — Understand your documents easily">
   <meta id="tw-desc" name="twitter:description" content="Explain contracts, bills & official documents in plain language. Free, private, multilingual.">
-  <meta name="twitter:image" content="https://documate-pi.vercel.app/og.jpg">
+  <meta name="twitter:image" content="https://documate.work/og.jpg">
 
   <!-- Favicon -->
   <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>📄</text></svg>">
 
   <!-- JSON-LD Organization (static) -->
   <script type="application/ld+json">
-  {"@context":"https://schema.org","@type":"Organization","name":"DocuMate","url":"https://documate-pi.vercel.app/","logo":"https://documate-pi.vercel.app/og.jpg"}
+  {"@context":"https://schema.org","@type":"Organization","name":"DocuMate","url":"https://documate.work/","logo":"https://documate.work/og.jpg"}
   </script>
   <!-- JSON-LD WebSite (lang is updated at runtime) -->
-  <script type="application/ld+json" id="jsonld-website">{"@context":"https://schema.org","@type":"WebSite","name":"DocuMate","url":"https://documate-pi.vercel.app/","inLanguage":"en","description":"Explain contracts, bills & official documents in plain language."}</script>
+  <script type="application/ld+json" id="jsonld-website">{"@context":"https://schema.org","@type":"WebSite","name":"DocuMate","url":"https://documate.work/","inLanguage":"en","description":"Explain contracts, bills & official documents in plain language."}</script>
 
   <!-- PDF.js & Mammoth.js (DOCX) -->
   <script src="https://unpkg.com/pdfjs-dist@4.7.76/build/pdf.min.js"></script>
@@ -289,7 +289,7 @@
       document.title = L.htmlTitle;
       $('#meta-title').textContent = L.htmlTitle;
       $('#meta-desc')?.setAttribute('content', L.htmlDesc);
-      const base = 'https://documate-pi.vercel.app';
+      const base = 'https://documate.work';
       const path = LANG_PATH[lang] || '/';
       $('#link-canonical')?.setAttribute('href', base + path);
       $('#og-url')?.setAttribute('content', base + path);
@@ -299,7 +299,7 @@
       $('#tw-desc')?.setAttribute('content', L.htmlDesc);
 
       // JSON-LD website
-      const ld = {"@context":"https://schema.org","@type":"WebSite","name":"DocuMate","url":"https://documate-pi.vercel.app/","inLanguage":lang,"description":L.htmlDesc};
+      const ld = {"@context":"https://schema.org","@type":"WebSite","name":"DocuMate","url":"https://documate.work/","inLanguage":lang,"description":L.htmlDesc};
       $('#jsonld-website').textContent = JSON.stringify(ld);
 
       // Update select value label text (keep options static)

--- a/en/index.html
+++ b/en/index.html
@@ -6,49 +6,49 @@
   <meta name="robots" content="index,follow" />
 
   <!-- Google Search Console -->
-  <meta name="google-site-verification" content="yHzn771ZljIbFj8wJJlnJ2FVIw9YjW1w0EJlZImH0QA" />
+  <meta name="google-site-verification" content="NOUVEAU_TOKEN_DOCUMATE_WORK" />
 
   <!-- AdSense global (keep once per page) -->
   <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9411950027978678" crossorigin="anonymous"></script>
 
   <title id="meta-title">DocuMate — Understand your documents easily</title>
   <meta id="meta-desc" name="description" content="DocuMate explains contracts, bills and official documents in plain language. Free, private, multilingual.">
-  <link id="link-canonical" rel="canonical" href="https://documate-pi.vercel.app/" />
+  <link id="link-canonical" rel="canonical" href="https://documate.work/" />
 
   <!-- Hreflang (static full set) -->
-  <link rel="alternate" hreflang="x-default" href="https://documate-pi.vercel.app/">
-  <link rel="alternate" hreflang="en" href="https://documate-pi.vercel.app/">
-  <link rel="alternate" hreflang="fr" href="https://documate-pi.vercel.app/fr/">
-  <link rel="alternate" hreflang="de" href="https://documate-pi.vercel.app/de/">
-  <link rel="alternate" hreflang="es" href="https://documate-pi.vercel.app/es/">
-  <link rel="alternate" hreflang="it" href="https://documate-pi.vercel.app/it/">
-  <link rel="alternate" hreflang="zh" href="https://documate-pi.vercel.app/zh/">
-  <link rel="alternate" hreflang="hi" href="https://documate-pi.vercel.app/hi/">
-  <link rel="alternate" hreflang="ar" href="https://documate-pi.vercel.app/ar/">
-  <link rel="alternate" hreflang="pt" href="https://documate-pi.vercel.app/pt/">
-  <link rel="alternate" hreflang="ru" href="https://documate-pi.vercel.app/ru/">
-  <link rel="alternate" hreflang="bn" href="https://documate-pi.vercel.app/bn/">
+  <link rel="alternate" hreflang="x-default" href="https://documate.work/">
+  <link rel="alternate" hreflang="en" href="https://documate.work/">
+  <link rel="alternate" hreflang="fr" href="https://documate.work/fr/">
+  <link rel="alternate" hreflang="de" href="https://documate.work/de/">
+  <link rel="alternate" hreflang="es" href="https://documate.work/es/">
+  <link rel="alternate" hreflang="it" href="https://documate.work/it/">
+  <link rel="alternate" hreflang="zh" href="https://documate.work/zh/">
+  <link rel="alternate" hreflang="hi" href="https://documate.work/hi/">
+  <link rel="alternate" hreflang="ar" href="https://documate.work/ar/">
+  <link rel="alternate" hreflang="pt" href="https://documate.work/pt/">
+  <link rel="alternate" hreflang="ru" href="https://documate.work/ru/">
+  <link rel="alternate" hreflang="bn" href="https://documate.work/bn/">
 
   <!-- Open Graph / Twitter, will be rewritten by JS on load -->
   <meta property="og:type" content="website">
-  <meta id="og-url" property="og:url" content="https://documate-pi.vercel.app/">
+  <meta id="og-url" property="og:url" content="https://documate.work/">
   <meta id="og-title" property="og:title" content="DocuMate — Understand your documents easily">
   <meta id="og-desc" property="og:description" content="Explain contracts, bills & official documents in plain language. Free, private, multilingual.">
-  <meta property="og:image" content="https://documate-pi.vercel.app/og.jpg">
+  <meta property="og:image" content="https://documate.work/og.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta id="tw-title" name="twitter:title" content="DocuMate — Understand your documents easily">
   <meta id="tw-desc" name="twitter:description" content="Explain contracts, bills & official documents in plain language. Free, private, multilingual.">
-  <meta name="twitter:image" content="https://documate-pi.vercel.app/og.jpg">
+  <meta name="twitter:image" content="https://documate.work/og.jpg">
 
   <!-- Favicon -->
   <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>📄</text></svg>">
 
   <!-- JSON-LD Organization (static) -->
   <script type="application/ld+json">
-  {"@context":"https://schema.org","@type":"Organization","name":"DocuMate","url":"https://documate-pi.vercel.app/","logo":"https://documate-pi.vercel.app/og.jpg"}
+  {"@context":"https://schema.org","@type":"Organization","name":"DocuMate","url":"https://documate.work/","logo":"https://documate.work/og.jpg"}
   </script>
   <!-- JSON-LD WebSite (lang is updated at runtime) -->
-  <script type="application/ld+json" id="jsonld-website">{"@context":"https://schema.org","@type":"WebSite","name":"DocuMate","url":"https://documate-pi.vercel.app/","inLanguage":"en","description":"Explain contracts, bills & official documents in plain language."}</script>
+  <script type="application/ld+json" id="jsonld-website">{"@context":"https://schema.org","@type":"WebSite","name":"DocuMate","url":"https://documate.work/","inLanguage":"en","description":"Explain contracts, bills & official documents in plain language."}</script>
 
   <!-- PDF.js & Mammoth.js (DOCX) -->
   <script src="https://unpkg.com/pdfjs-dist@4.7.76/build/pdf.min.js"></script>
@@ -289,7 +289,7 @@
       document.title = L.htmlTitle;
       $('#meta-title').textContent = L.htmlTitle;
       $('#meta-desc')?.setAttribute('content', L.htmlDesc);
-      const base = 'https://documate-pi.vercel.app';
+      const base = 'https://documate.work';
       const path = LANG_PATH[lang] || '/';
       $('#link-canonical')?.setAttribute('href', base + path);
       $('#og-url')?.setAttribute('content', base + path);
@@ -299,7 +299,7 @@
       $('#tw-desc')?.setAttribute('content', L.htmlDesc);
 
       // JSON-LD website
-      const ld = {"@context":"https://schema.org","@type":"WebSite","name":"DocuMate","url":"https://documate-pi.vercel.app/","inLanguage":lang,"description":L.htmlDesc};
+      const ld = {"@context":"https://schema.org","@type":"WebSite","name":"DocuMate","url":"https://documate.work/","inLanguage":lang,"description":L.htmlDesc};
       $('#jsonld-website').textContent = JSON.stringify(ld);
 
       // Update select value label text (keep options static)

--- a/es/index.html
+++ b/es/index.html
@@ -6,49 +6,49 @@
   <meta name="robots" content="index,follow" />
 
   <!-- Google Search Console -->
-  <meta name="google-site-verification" content="yHzn771ZljIbFj8wJJlnJ2FVIw9YjW1w0EJlZImH0QA" />
+  <meta name="google-site-verification" content="NOUVEAU_TOKEN_DOCUMATE_WORK" />
 
   <!-- AdSense global (keep once per page) -->
   <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9411950027978678" crossorigin="anonymous"></script>
 
   <title id="meta-title">DocuMate — Understand your documents easily</title>
   <meta id="meta-desc" name="description" content="DocuMate explains contracts, bills and official documents in plain language. Free, private, multilingual.">
-  <link id="link-canonical" rel="canonical" href="https://documate-pi.vercel.app/" />
+  <link id="link-canonical" rel="canonical" href="https://documate.work/es/" />
 
   <!-- Hreflang (static full set) -->
-  <link rel="alternate" hreflang="x-default" href="https://documate-pi.vercel.app/">
-  <link rel="alternate" hreflang="en" href="https://documate-pi.vercel.app/">
-  <link rel="alternate" hreflang="fr" href="https://documate-pi.vercel.app/fr/">
-  <link rel="alternate" hreflang="de" href="https://documate-pi.vercel.app/de/">
-  <link rel="alternate" hreflang="es" href="https://documate-pi.vercel.app/es/">
-  <link rel="alternate" hreflang="it" href="https://documate-pi.vercel.app/it/">
-  <link rel="alternate" hreflang="zh" href="https://documate-pi.vercel.app/zh/">
-  <link rel="alternate" hreflang="hi" href="https://documate-pi.vercel.app/hi/">
-  <link rel="alternate" hreflang="ar" href="https://documate-pi.vercel.app/ar/">
-  <link rel="alternate" hreflang="pt" href="https://documate-pi.vercel.app/pt/">
-  <link rel="alternate" hreflang="ru" href="https://documate-pi.vercel.app/ru/">
-  <link rel="alternate" hreflang="bn" href="https://documate-pi.vercel.app/bn/">
+  <link rel="alternate" hreflang="x-default" href="https://documate.work/">
+  <link rel="alternate" hreflang="en" href="https://documate.work/">
+  <link rel="alternate" hreflang="fr" href="https://documate.work/fr/">
+  <link rel="alternate" hreflang="de" href="https://documate.work/de/">
+  <link rel="alternate" hreflang="es" href="https://documate.work/es/">
+  <link rel="alternate" hreflang="it" href="https://documate.work/it/">
+  <link rel="alternate" hreflang="zh" href="https://documate.work/zh/">
+  <link rel="alternate" hreflang="hi" href="https://documate.work/hi/">
+  <link rel="alternate" hreflang="ar" href="https://documate.work/ar/">
+  <link rel="alternate" hreflang="pt" href="https://documate.work/pt/">
+  <link rel="alternate" hreflang="ru" href="https://documate.work/ru/">
+  <link rel="alternate" hreflang="bn" href="https://documate.work/bn/">
 
   <!-- Open Graph / Twitter, will be rewritten by JS on load -->
   <meta property="og:type" content="website">
-  <meta id="og-url" property="og:url" content="https://documate-pi.vercel.app/">
+  <meta id="og-url" property="og:url" content="https://documate.work/es/">
   <meta id="og-title" property="og:title" content="DocuMate — Understand your documents easily">
   <meta id="og-desc" property="og:description" content="Explain contracts, bills & official documents in plain language. Free, private, multilingual.">
-  <meta property="og:image" content="https://documate-pi.vercel.app/og.jpg">
+  <meta property="og:image" content="https://documate.work/og.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta id="tw-title" name="twitter:title" content="DocuMate — Understand your documents easily">
   <meta id="tw-desc" name="twitter:description" content="Explain contracts, bills & official documents in plain language. Free, private, multilingual.">
-  <meta name="twitter:image" content="https://documate-pi.vercel.app/og.jpg">
+  <meta name="twitter:image" content="https://documate.work/og.jpg">
 
   <!-- Favicon -->
   <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>📄</text></svg>">
 
   <!-- JSON-LD Organization (static) -->
   <script type="application/ld+json">
-  {"@context":"https://schema.org","@type":"Organization","name":"DocuMate","url":"https://documate-pi.vercel.app/","logo":"https://documate-pi.vercel.app/og.jpg"}
+  {"@context":"https://schema.org","@type":"Organization","name":"DocuMate","url":"https://documate.work/","logo":"https://documate.work/og.jpg"}
   </script>
   <!-- JSON-LD WebSite (lang is updated at runtime) -->
-  <script type="application/ld+json" id="jsonld-website">{"@context":"https://schema.org","@type":"WebSite","name":"DocuMate","url":"https://documate-pi.vercel.app/","inLanguage":"en","description":"Explain contracts, bills & official documents in plain language."}</script>
+  <script type="application/ld+json" id="jsonld-website">{"@context":"https://schema.org","@type":"WebSite","name":"DocuMate","url":"https://documate.work/","inLanguage":"en","description":"Explain contracts, bills & official documents in plain language."}</script>
 
   <!-- PDF.js & Mammoth.js (DOCX) -->
   <script src="https://unpkg.com/pdfjs-dist@4.7.76/build/pdf.min.js"></script>
@@ -289,7 +289,7 @@
       document.title = L.htmlTitle;
       $('#meta-title').textContent = L.htmlTitle;
       $('#meta-desc')?.setAttribute('content', L.htmlDesc);
-      const base = 'https://documate-pi.vercel.app';
+      const base = 'https://documate.work';
       const path = LANG_PATH[lang] || '/';
       $('#link-canonical')?.setAttribute('href', base + path);
       $('#og-url')?.setAttribute('content', base + path);
@@ -299,7 +299,7 @@
       $('#tw-desc')?.setAttribute('content', L.htmlDesc);
 
       // JSON-LD website
-      const ld = {"@context":"https://schema.org","@type":"WebSite","name":"DocuMate","url":"https://documate-pi.vercel.app/","inLanguage":lang,"description":L.htmlDesc};
+      const ld = {"@context":"https://schema.org","@type":"WebSite","name":"DocuMate","url":"https://documate.work/","inLanguage":lang,"description":L.htmlDesc};
       $('#jsonld-website').textContent = JSON.stringify(ld);
 
       // Update select value label text (keep options static)

--- a/fr/index.html
+++ b/fr/index.html
@@ -6,49 +6,49 @@
   <meta name="robots" content="index,follow" />
 
   <!-- Google Search Console -->
-  <meta name="google-site-verification" content="yHzn771ZljIbFj8wJJlnJ2FVIw9YjW1w0EJlZImH0QA" />
+  <meta name="google-site-verification" content="NOUVEAU_TOKEN_DOCUMATE_WORK" />
 
   <!-- AdSense global (keep once per page) -->
   <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9411950027978678" crossorigin="anonymous"></script>
 
   <title id="meta-title">DocuMate — Understand your documents easily</title>
   <meta id="meta-desc" name="description" content="DocuMate explains contracts, bills and official documents in plain language. Free, private, multilingual.">
-  <link id="link-canonical" rel="canonical" href="https://documate-pi.vercel.app/" />
+  <link id="link-canonical" rel="canonical" href="https://documate.work/fr/" />
 
   <!-- Hreflang (static full set) -->
-  <link rel="alternate" hreflang="x-default" href="https://documate-pi.vercel.app/">
-  <link rel="alternate" hreflang="en" href="https://documate-pi.vercel.app/">
-  <link rel="alternate" hreflang="fr" href="https://documate-pi.vercel.app/fr/">
-  <link rel="alternate" hreflang="de" href="https://documate-pi.vercel.app/de/">
-  <link rel="alternate" hreflang="es" href="https://documate-pi.vercel.app/es/">
-  <link rel="alternate" hreflang="it" href="https://documate-pi.vercel.app/it/">
-  <link rel="alternate" hreflang="zh" href="https://documate-pi.vercel.app/zh/">
-  <link rel="alternate" hreflang="hi" href="https://documate-pi.vercel.app/hi/">
-  <link rel="alternate" hreflang="ar" href="https://documate-pi.vercel.app/ar/">
-  <link rel="alternate" hreflang="pt" href="https://documate-pi.vercel.app/pt/">
-  <link rel="alternate" hreflang="ru" href="https://documate-pi.vercel.app/ru/">
-  <link rel="alternate" hreflang="bn" href="https://documate-pi.vercel.app/bn/">
+  <link rel="alternate" hreflang="x-default" href="https://documate.work/">
+  <link rel="alternate" hreflang="en" href="https://documate.work/">
+  <link rel="alternate" hreflang="fr" href="https://documate.work/fr/">
+  <link rel="alternate" hreflang="de" href="https://documate.work/de/">
+  <link rel="alternate" hreflang="es" href="https://documate.work/es/">
+  <link rel="alternate" hreflang="it" href="https://documate.work/it/">
+  <link rel="alternate" hreflang="zh" href="https://documate.work/zh/">
+  <link rel="alternate" hreflang="hi" href="https://documate.work/hi/">
+  <link rel="alternate" hreflang="ar" href="https://documate.work/ar/">
+  <link rel="alternate" hreflang="pt" href="https://documate.work/pt/">
+  <link rel="alternate" hreflang="ru" href="https://documate.work/ru/">
+  <link rel="alternate" hreflang="bn" href="https://documate.work/bn/">
 
   <!-- Open Graph / Twitter, will be rewritten by JS on load -->
   <meta property="og:type" content="website">
-  <meta id="og-url" property="og:url" content="https://documate-pi.vercel.app/">
+  <meta id="og-url" property="og:url" content="https://documate.work/fr/">
   <meta id="og-title" property="og:title" content="DocuMate — Understand your documents easily">
   <meta id="og-desc" property="og:description" content="Explain contracts, bills & official documents in plain language. Free, private, multilingual.">
-  <meta property="og:image" content="https://documate-pi.vercel.app/og.jpg">
+  <meta property="og:image" content="https://documate.work/og.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta id="tw-title" name="twitter:title" content="DocuMate — Understand your documents easily">
   <meta id="tw-desc" name="twitter:description" content="Explain contracts, bills & official documents in plain language. Free, private, multilingual.">
-  <meta name="twitter:image" content="https://documate-pi.vercel.app/og.jpg">
+  <meta name="twitter:image" content="https://documate.work/og.jpg">
 
   <!-- Favicon -->
   <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>📄</text></svg>">
 
   <!-- JSON-LD Organization (static) -->
   <script type="application/ld+json">
-  {"@context":"https://schema.org","@type":"Organization","name":"DocuMate","url":"https://documate-pi.vercel.app/","logo":"https://documate-pi.vercel.app/og.jpg"}
+  {"@context":"https://schema.org","@type":"Organization","name":"DocuMate","url":"https://documate.work/","logo":"https://documate.work/og.jpg"}
   </script>
   <!-- JSON-LD WebSite (lang is updated at runtime) -->
-  <script type="application/ld+json" id="jsonld-website">{"@context":"https://schema.org","@type":"WebSite","name":"DocuMate","url":"https://documate-pi.vercel.app/","inLanguage":"en","description":"Explain contracts, bills & official documents in plain language."}</script>
+  <script type="application/ld+json" id="jsonld-website">{"@context":"https://schema.org","@type":"WebSite","name":"DocuMate","url":"https://documate.work/","inLanguage":"en","description":"Explain contracts, bills & official documents in plain language."}</script>
 
   <!-- PDF.js & Mammoth.js (DOCX) -->
   <script src="https://unpkg.com/pdfjs-dist@4.7.76/build/pdf.min.js"></script>
@@ -289,7 +289,7 @@
       document.title = L.htmlTitle;
       $('#meta-title').textContent = L.htmlTitle;
       $('#meta-desc')?.setAttribute('content', L.htmlDesc);
-      const base = 'https://documate-pi.vercel.app';
+      const base = 'https://documate.work';
       const path = LANG_PATH[lang] || '/';
       $('#link-canonical')?.setAttribute('href', base + path);
       $('#og-url')?.setAttribute('content', base + path);
@@ -299,7 +299,7 @@
       $('#tw-desc')?.setAttribute('content', L.htmlDesc);
 
       // JSON-LD website
-      const ld = {"@context":"https://schema.org","@type":"WebSite","name":"DocuMate","url":"https://documate-pi.vercel.app/","inLanguage":lang,"description":L.htmlDesc};
+      const ld = {"@context":"https://schema.org","@type":"WebSite","name":"DocuMate","url":"https://documate.work/","inLanguage":lang,"description":L.htmlDesc};
       $('#jsonld-website').textContent = JSON.stringify(ld);
 
       // Update select value label text (keep options static)

--- a/hi/index.html
+++ b/hi/index.html
@@ -6,49 +6,49 @@
   <meta name="robots" content="index,follow" />
 
   <!-- Google Search Console -->
-  <meta name="google-site-verification" content="yHzn771ZljIbFj8wJJlnJ2FVIw9YjW1w0EJlZImH0QA" />
+  <meta name="google-site-verification" content="NOUVEAU_TOKEN_DOCUMATE_WORK" />
 
   <!-- AdSense global (keep once per page) -->
   <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9411950027978678" crossorigin="anonymous"></script>
 
   <title id="meta-title">DocuMate — Understand your documents easily</title>
   <meta id="meta-desc" name="description" content="DocuMate explains contracts, bills and official documents in plain language. Free, private, multilingual.">
-  <link id="link-canonical" rel="canonical" href="https://documate-pi.vercel.app/" />
+  <link id="link-canonical" rel="canonical" href="https://documate.work/hi/" />
 
   <!-- Hreflang (static full set) -->
-  <link rel="alternate" hreflang="x-default" href="https://documate-pi.vercel.app/">
-  <link rel="alternate" hreflang="en" href="https://documate-pi.vercel.app/">
-  <link rel="alternate" hreflang="fr" href="https://documate-pi.vercel.app/fr/">
-  <link rel="alternate" hreflang="de" href="https://documate-pi.vercel.app/de/">
-  <link rel="alternate" hreflang="es" href="https://documate-pi.vercel.app/es/">
-  <link rel="alternate" hreflang="it" href="https://documate-pi.vercel.app/it/">
-  <link rel="alternate" hreflang="zh" href="https://documate-pi.vercel.app/zh/">
-  <link rel="alternate" hreflang="hi" href="https://documate-pi.vercel.app/hi/">
-  <link rel="alternate" hreflang="ar" href="https://documate-pi.vercel.app/ar/">
-  <link rel="alternate" hreflang="pt" href="https://documate-pi.vercel.app/pt/">
-  <link rel="alternate" hreflang="ru" href="https://documate-pi.vercel.app/ru/">
-  <link rel="alternate" hreflang="bn" href="https://documate-pi.vercel.app/bn/">
+  <link rel="alternate" hreflang="x-default" href="https://documate.work/">
+  <link rel="alternate" hreflang="en" href="https://documate.work/">
+  <link rel="alternate" hreflang="fr" href="https://documate.work/fr/">
+  <link rel="alternate" hreflang="de" href="https://documate.work/de/">
+  <link rel="alternate" hreflang="es" href="https://documate.work/es/">
+  <link rel="alternate" hreflang="it" href="https://documate.work/it/">
+  <link rel="alternate" hreflang="zh" href="https://documate.work/zh/">
+  <link rel="alternate" hreflang="hi" href="https://documate.work/hi/">
+  <link rel="alternate" hreflang="ar" href="https://documate.work/ar/">
+  <link rel="alternate" hreflang="pt" href="https://documate.work/pt/">
+  <link rel="alternate" hreflang="ru" href="https://documate.work/ru/">
+  <link rel="alternate" hreflang="bn" href="https://documate.work/bn/">
 
   <!-- Open Graph / Twitter, will be rewritten by JS on load -->
   <meta property="og:type" content="website">
-  <meta id="og-url" property="og:url" content="https://documate-pi.vercel.app/">
+  <meta id="og-url" property="og:url" content="https://documate.work/hi/">
   <meta id="og-title" property="og:title" content="DocuMate — Understand your documents easily">
   <meta id="og-desc" property="og:description" content="Explain contracts, bills & official documents in plain language. Free, private, multilingual.">
-  <meta property="og:image" content="https://documate-pi.vercel.app/og.jpg">
+  <meta property="og:image" content="https://documate.work/og.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta id="tw-title" name="twitter:title" content="DocuMate — Understand your documents easily">
   <meta id="tw-desc" name="twitter:description" content="Explain contracts, bills & official documents in plain language. Free, private, multilingual.">
-  <meta name="twitter:image" content="https://documate-pi.vercel.app/og.jpg">
+  <meta name="twitter:image" content="https://documate.work/og.jpg">
 
   <!-- Favicon -->
   <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>📄</text></svg>">
 
   <!-- JSON-LD Organization (static) -->
   <script type="application/ld+json">
-  {"@context":"https://schema.org","@type":"Organization","name":"DocuMate","url":"https://documate-pi.vercel.app/","logo":"https://documate-pi.vercel.app/og.jpg"}
+  {"@context":"https://schema.org","@type":"Organization","name":"DocuMate","url":"https://documate.work/","logo":"https://documate.work/og.jpg"}
   </script>
   <!-- JSON-LD WebSite (lang is updated at runtime) -->
-  <script type="application/ld+json" id="jsonld-website">{"@context":"https://schema.org","@type":"WebSite","name":"DocuMate","url":"https://documate-pi.vercel.app/","inLanguage":"en","description":"Explain contracts, bills & official documents in plain language."}</script>
+  <script type="application/ld+json" id="jsonld-website">{"@context":"https://schema.org","@type":"WebSite","name":"DocuMate","url":"https://documate.work/","inLanguage":"en","description":"Explain contracts, bills & official documents in plain language."}</script>
 
   <!-- PDF.js & Mammoth.js (DOCX) -->
   <script src="https://unpkg.com/pdfjs-dist@4.7.76/build/pdf.min.js"></script>
@@ -289,7 +289,7 @@
       document.title = L.htmlTitle;
       $('#meta-title').textContent = L.htmlTitle;
       $('#meta-desc')?.setAttribute('content', L.htmlDesc);
-      const base = 'https://documate-pi.vercel.app';
+      const base = 'https://documate.work';
       const path = LANG_PATH[lang] || '/';
       $('#link-canonical')?.setAttribute('href', base + path);
       $('#og-url')?.setAttribute('content', base + path);
@@ -299,7 +299,7 @@
       $('#tw-desc')?.setAttribute('content', L.htmlDesc);
 
       // JSON-LD website
-      const ld = {"@context":"https://schema.org","@type":"WebSite","name":"DocuMate","url":"https://documate-pi.vercel.app/","inLanguage":lang,"description":L.htmlDesc};
+      const ld = {"@context":"https://schema.org","@type":"WebSite","name":"DocuMate","url":"https://documate.work/","inLanguage":lang,"description":L.htmlDesc};
       $('#jsonld-website').textContent = JSON.stringify(ld);
 
       // Update select value label text (keep options static)

--- a/index.html
+++ b/index.html
@@ -6,49 +6,49 @@
   <meta name="robots" content="index,follow" />
 
   <!-- Google Search Console -->
-  <meta name="google-site-verification" content="yHzn771ZljIbFj8wJJlnJ2FVIw9YjW1w0EJlZImH0QA" />
+  <meta name="google-site-verification" content="NOUVEAU_TOKEN_DOCUMATE_WORK" />
 
   <!-- AdSense global (keep once per page) -->
   <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9411950027978678" crossorigin="anonymous"></script>
 
   <title id="meta-title">DocuMate — Understand your documents easily</title>
   <meta id="meta-desc" name="description" content="DocuMate explains contracts, bills and official documents in plain language. Free, private, multilingual.">
-  <link id="link-canonical" rel="canonical" href="https://documate-pi.vercel.app/" />
+  <link id="link-canonical" rel="canonical" href="https://documate.work/" />
 
   <!-- Hreflang (static full set) -->
-  <link rel="alternate" hreflang="x-default" href="https://documate-pi.vercel.app/">
-  <link rel="alternate" hreflang="en" href="https://documate-pi.vercel.app/">
-  <link rel="alternate" hreflang="fr" href="https://documate-pi.vercel.app/fr/">
-  <link rel="alternate" hreflang="de" href="https://documate-pi.vercel.app/de/">
-  <link rel="alternate" hreflang="es" href="https://documate-pi.vercel.app/es/">
-  <link rel="alternate" hreflang="it" href="https://documate-pi.vercel.app/it/">
-  <link rel="alternate" hreflang="zh" href="https://documate-pi.vercel.app/zh/">
-  <link rel="alternate" hreflang="hi" href="https://documate-pi.vercel.app/hi/">
-  <link rel="alternate" hreflang="ar" href="https://documate-pi.vercel.app/ar/">
-  <link rel="alternate" hreflang="pt" href="https://documate-pi.vercel.app/pt/">
-  <link rel="alternate" hreflang="ru" href="https://documate-pi.vercel.app/ru/">
-  <link rel="alternate" hreflang="bn" href="https://documate-pi.vercel.app/bn/">
+  <link rel="alternate" hreflang="x-default" href="https://documate.work/">
+  <link rel="alternate" hreflang="en" href="https://documate.work/">
+  <link rel="alternate" hreflang="fr" href="https://documate.work/fr/">
+  <link rel="alternate" hreflang="de" href="https://documate.work/de/">
+  <link rel="alternate" hreflang="es" href="https://documate.work/es/">
+  <link rel="alternate" hreflang="it" href="https://documate.work/it/">
+  <link rel="alternate" hreflang="zh" href="https://documate.work/zh/">
+  <link rel="alternate" hreflang="hi" href="https://documate.work/hi/">
+  <link rel="alternate" hreflang="ar" href="https://documate.work/ar/">
+  <link rel="alternate" hreflang="pt" href="https://documate.work/pt/">
+  <link rel="alternate" hreflang="ru" href="https://documate.work/ru/">
+  <link rel="alternate" hreflang="bn" href="https://documate.work/bn/">
 
   <!-- Open Graph / Twitter, will be rewritten by JS on load -->
   <meta property="og:type" content="website">
-  <meta id="og-url" property="og:url" content="https://documate-pi.vercel.app/">
+  <meta id="og-url" property="og:url" content="https://documate.work/">
   <meta id="og-title" property="og:title" content="DocuMate — Understand your documents easily">
   <meta id="og-desc" property="og:description" content="Explain contracts, bills & official documents in plain language. Free, private, multilingual.">
-  <meta property="og:image" content="https://documate-pi.vercel.app/og.jpg">
+  <meta property="og:image" content="https://documate.work/og.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta id="tw-title" name="twitter:title" content="DocuMate — Understand your documents easily">
   <meta id="tw-desc" name="twitter:description" content="Explain contracts, bills & official documents in plain language. Free, private, multilingual.">
-  <meta name="twitter:image" content="https://documate-pi.vercel.app/og.jpg">
+  <meta name="twitter:image" content="https://documate.work/og.jpg">
 
   <!-- Favicon -->
   <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>📄</text></svg>">
 
   <!-- JSON-LD Organization (static) -->
   <script type="application/ld+json">
-  {"@context":"https://schema.org","@type":"Organization","name":"DocuMate","url":"https://documate-pi.vercel.app/","logo":"https://documate-pi.vercel.app/og.jpg"}
+  {"@context":"https://schema.org","@type":"Organization","name":"DocuMate","url":"https://documate.work/","logo":"https://documate.work/og.jpg"}
   </script>
   <!-- JSON-LD WebSite (lang is updated at runtime) -->
-  <script type="application/ld+json" id="jsonld-website">{"@context":"https://schema.org","@type":"WebSite","name":"DocuMate","url":"https://documate-pi.vercel.app/","inLanguage":"en","description":"Explain contracts, bills & official documents in plain language."}</script>
+  <script type="application/ld+json" id="jsonld-website">{"@context":"https://schema.org","@type":"WebSite","name":"DocuMate","url":"https://documate.work/","inLanguage":"en","description":"Explain contracts, bills & official documents in plain language."}</script>
 
   <!-- PDF.js & Mammoth.js (DOCX) -->
   <script src="https://unpkg.com/pdfjs-dist@4.7.76/build/pdf.min.js"></script>
@@ -289,7 +289,7 @@
       document.title = L.htmlTitle;
       $('#meta-title').textContent = L.htmlTitle;
       $('#meta-desc')?.setAttribute('content', L.htmlDesc);
-      const base = 'https://documate-pi.vercel.app';
+      const base = 'https://documate.work';
       const path = LANG_PATH[lang] || '/';
       $('#link-canonical')?.setAttribute('href', base + path);
       $('#og-url')?.setAttribute('content', base + path);
@@ -299,7 +299,7 @@
       $('#tw-desc')?.setAttribute('content', L.htmlDesc);
 
       // JSON-LD website
-      const ld = {"@context":"https://schema.org","@type":"WebSite","name":"DocuMate","url":"https://documate-pi.vercel.app/","inLanguage":lang,"description":L.htmlDesc};
+      const ld = {"@context":"https://schema.org","@type":"WebSite","name":"DocuMate","url":"https://documate.work/","inLanguage":lang,"description":L.htmlDesc};
       $('#jsonld-website').textContent = JSON.stringify(ld);
 
       // Update select value label text (keep options static)

--- a/it/index.html
+++ b/it/index.html
@@ -6,49 +6,49 @@
   <meta name="robots" content="index,follow" />
 
   <!-- Google Search Console -->
-  <meta name="google-site-verification" content="yHzn771ZljIbFj8wJJlnJ2FVIw9YjW1w0EJlZImH0QA" />
+  <meta name="google-site-verification" content="NOUVEAU_TOKEN_DOCUMATE_WORK" />
 
   <!-- AdSense global (keep once per page) -->
   <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9411950027978678" crossorigin="anonymous"></script>
 
   <title id="meta-title">DocuMate — Understand your documents easily</title>
   <meta id="meta-desc" name="description" content="DocuMate explains contracts, bills and official documents in plain language. Free, private, multilingual.">
-  <link id="link-canonical" rel="canonical" href="https://documate-pi.vercel.app/" />
+  <link id="link-canonical" rel="canonical" href="https://documate.work/it/" />
 
   <!-- Hreflang (static full set) -->
-  <link rel="alternate" hreflang="x-default" href="https://documate-pi.vercel.app/">
-  <link rel="alternate" hreflang="en" href="https://documate-pi.vercel.app/">
-  <link rel="alternate" hreflang="fr" href="https://documate-pi.vercel.app/fr/">
-  <link rel="alternate" hreflang="de" href="https://documate-pi.vercel.app/de/">
-  <link rel="alternate" hreflang="es" href="https://documate-pi.vercel.app/es/">
-  <link rel="alternate" hreflang="it" href="https://documate-pi.vercel.app/it/">
-  <link rel="alternate" hreflang="zh" href="https://documate-pi.vercel.app/zh/">
-  <link rel="alternate" hreflang="hi" href="https://documate-pi.vercel.app/hi/">
-  <link rel="alternate" hreflang="ar" href="https://documate-pi.vercel.app/ar/">
-  <link rel="alternate" hreflang="pt" href="https://documate-pi.vercel.app/pt/">
-  <link rel="alternate" hreflang="ru" href="https://documate-pi.vercel.app/ru/">
-  <link rel="alternate" hreflang="bn" href="https://documate-pi.vercel.app/bn/">
+  <link rel="alternate" hreflang="x-default" href="https://documate.work/">
+  <link rel="alternate" hreflang="en" href="https://documate.work/">
+  <link rel="alternate" hreflang="fr" href="https://documate.work/fr/">
+  <link rel="alternate" hreflang="de" href="https://documate.work/de/">
+  <link rel="alternate" hreflang="es" href="https://documate.work/es/">
+  <link rel="alternate" hreflang="it" href="https://documate.work/it/">
+  <link rel="alternate" hreflang="zh" href="https://documate.work/zh/">
+  <link rel="alternate" hreflang="hi" href="https://documate.work/hi/">
+  <link rel="alternate" hreflang="ar" href="https://documate.work/ar/">
+  <link rel="alternate" hreflang="pt" href="https://documate.work/pt/">
+  <link rel="alternate" hreflang="ru" href="https://documate.work/ru/">
+  <link rel="alternate" hreflang="bn" href="https://documate.work/bn/">
 
   <!-- Open Graph / Twitter, will be rewritten by JS on load -->
   <meta property="og:type" content="website">
-  <meta id="og-url" property="og:url" content="https://documate-pi.vercel.app/">
+  <meta id="og-url" property="og:url" content="https://documate.work/it/">
   <meta id="og-title" property="og:title" content="DocuMate — Understand your documents easily">
   <meta id="og-desc" property="og:description" content="Explain contracts, bills & official documents in plain language. Free, private, multilingual.">
-  <meta property="og:image" content="https://documate-pi.vercel.app/og.jpg">
+  <meta property="og:image" content="https://documate.work/og.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta id="tw-title" name="twitter:title" content="DocuMate — Understand your documents easily">
   <meta id="tw-desc" name="twitter:description" content="Explain contracts, bills & official documents in plain language. Free, private, multilingual.">
-  <meta name="twitter:image" content="https://documate-pi.vercel.app/og.jpg">
+  <meta name="twitter:image" content="https://documate.work/og.jpg">
 
   <!-- Favicon -->
   <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>📄</text></svg>">
 
   <!-- JSON-LD Organization (static) -->
   <script type="application/ld+json">
-  {"@context":"https://schema.org","@type":"Organization","name":"DocuMate","url":"https://documate-pi.vercel.app/","logo":"https://documate-pi.vercel.app/og.jpg"}
+  {"@context":"https://schema.org","@type":"Organization","name":"DocuMate","url":"https://documate.work/","logo":"https://documate.work/og.jpg"}
   </script>
   <!-- JSON-LD WebSite (lang is updated at runtime) -->
-  <script type="application/ld+json" id="jsonld-website">{"@context":"https://schema.org","@type":"WebSite","name":"DocuMate","url":"https://documate-pi.vercel.app/","inLanguage":"en","description":"Explain contracts, bills & official documents in plain language."}</script>
+  <script type="application/ld+json" id="jsonld-website">{"@context":"https://schema.org","@type":"WebSite","name":"DocuMate","url":"https://documate.work/","inLanguage":"en","description":"Explain contracts, bills & official documents in plain language."}</script>
 
   <!-- PDF.js & Mammoth.js (DOCX) -->
   <script src="https://unpkg.com/pdfjs-dist@4.7.76/build/pdf.min.js"></script>
@@ -289,7 +289,7 @@
       document.title = L.htmlTitle;
       $('#meta-title').textContent = L.htmlTitle;
       $('#meta-desc')?.setAttribute('content', L.htmlDesc);
-      const base = 'https://documate-pi.vercel.app';
+      const base = 'https://documate.work';
       const path = LANG_PATH[lang] || '/';
       $('#link-canonical')?.setAttribute('href', base + path);
       $('#og-url')?.setAttribute('content', base + path);
@@ -299,7 +299,7 @@
       $('#tw-desc')?.setAttribute('content', L.htmlDesc);
 
       // JSON-LD website
-      const ld = {"@context":"https://schema.org","@type":"WebSite","name":"DocuMate","url":"https://documate-pi.vercel.app/","inLanguage":lang,"description":L.htmlDesc};
+      const ld = {"@context":"https://schema.org","@type":"WebSite","name":"DocuMate","url":"https://documate.work/","inLanguage":lang,"description":L.htmlDesc};
       $('#jsonld-website').textContent = JSON.stringify(ld);
 
       // Update select value label text (keep options static)

--- a/privacy.html
+++ b/privacy.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>DocuMate — Politique de confidentialité</title>
   <meta name="description" content="Politique de confidentialité DocuMate : traitement minimal des données, aucune conservation des documents, publicités avec consentement.">
-  <link rel="canonical" href="https://documate-pi.vercel.app/privacy.html" />
+  <link rel="canonical" href="https://documate.work/privacy.html" />
   <style>
     body{margin:0;font:16px/1.6 system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;color:#0f172a;background:#f7f9fc}
     main{max-width:900px;margin:24px auto;padding:0 16px}
@@ -24,7 +24,7 @@
       <p><em>Dernière mise à jour : 2 septembre 2025</em></p>
 
       <h2>Qui sommes-nous ?</h2>
-      <p><strong>DocuMate</strong> est un service gratuit qui explique en langage simple des documents (contrats, factures, courriers, etc.). Site : <a href="https://documate-pi.vercel.app/">documate-pi.vercel.app</a>.</p>
+      <p><strong>DocuMate</strong> est un service gratuit qui explique en langage simple des documents (contrats, factures, courriers, etc.). Site : <a href="https://documate.work/">documate.work</a>.</p>
 
       <h2>Principes</h2>
       <ul>

--- a/pt/index.html
+++ b/pt/index.html
@@ -6,49 +6,49 @@
   <meta name="robots" content="index,follow" />
 
   <!-- Google Search Console -->
-  <meta name="google-site-verification" content="yHzn771ZljIbFj8wJJlnJ2FVIw9YjW1w0EJlZImH0QA" />
+  <meta name="google-site-verification" content="NOUVEAU_TOKEN_DOCUMATE_WORK" />
 
   <!-- AdSense global (keep once per page) -->
   <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9411950027978678" crossorigin="anonymous"></script>
 
   <title id="meta-title">DocuMate — Understand your documents easily</title>
   <meta id="meta-desc" name="description" content="DocuMate explains contracts, bills and official documents in plain language. Free, private, multilingual.">
-  <link id="link-canonical" rel="canonical" href="https://documate-pi.vercel.app/" />
+  <link id="link-canonical" rel="canonical" href="https://documate.work/pt/" />
 
   <!-- Hreflang (static full set) -->
-  <link rel="alternate" hreflang="x-default" href="https://documate-pi.vercel.app/">
-  <link rel="alternate" hreflang="en" href="https://documate-pi.vercel.app/">
-  <link rel="alternate" hreflang="fr" href="https://documate-pi.vercel.app/fr/">
-  <link rel="alternate" hreflang="de" href="https://documate-pi.vercel.app/de/">
-  <link rel="alternate" hreflang="es" href="https://documate-pi.vercel.app/es/">
-  <link rel="alternate" hreflang="it" href="https://documate-pi.vercel.app/it/">
-  <link rel="alternate" hreflang="zh" href="https://documate-pi.vercel.app/zh/">
-  <link rel="alternate" hreflang="hi" href="https://documate-pi.vercel.app/hi/">
-  <link rel="alternate" hreflang="ar" href="https://documate-pi.vercel.app/ar/">
-  <link rel="alternate" hreflang="pt" href="https://documate-pi.vercel.app/pt/">
-  <link rel="alternate" hreflang="ru" href="https://documate-pi.vercel.app/ru/">
-  <link rel="alternate" hreflang="bn" href="https://documate-pi.vercel.app/bn/">
+  <link rel="alternate" hreflang="x-default" href="https://documate.work/">
+  <link rel="alternate" hreflang="en" href="https://documate.work/">
+  <link rel="alternate" hreflang="fr" href="https://documate.work/fr/">
+  <link rel="alternate" hreflang="de" href="https://documate.work/de/">
+  <link rel="alternate" hreflang="es" href="https://documate.work/es/">
+  <link rel="alternate" hreflang="it" href="https://documate.work/it/">
+  <link rel="alternate" hreflang="zh" href="https://documate.work/zh/">
+  <link rel="alternate" hreflang="hi" href="https://documate.work/hi/">
+  <link rel="alternate" hreflang="ar" href="https://documate.work/ar/">
+  <link rel="alternate" hreflang="pt" href="https://documate.work/pt/">
+  <link rel="alternate" hreflang="ru" href="https://documate.work/ru/">
+  <link rel="alternate" hreflang="bn" href="https://documate.work/bn/">
 
   <!-- Open Graph / Twitter, will be rewritten by JS on load -->
   <meta property="og:type" content="website">
-  <meta id="og-url" property="og:url" content="https://documate-pi.vercel.app/">
+  <meta id="og-url" property="og:url" content="https://documate.work/pt/">
   <meta id="og-title" property="og:title" content="DocuMate — Understand your documents easily">
   <meta id="og-desc" property="og:description" content="Explain contracts, bills & official documents in plain language. Free, private, multilingual.">
-  <meta property="og:image" content="https://documate-pi.vercel.app/og.jpg">
+  <meta property="og:image" content="https://documate.work/og.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta id="tw-title" name="twitter:title" content="DocuMate — Understand your documents easily">
   <meta id="tw-desc" name="twitter:description" content="Explain contracts, bills & official documents in plain language. Free, private, multilingual.">
-  <meta name="twitter:image" content="https://documate-pi.vercel.app/og.jpg">
+  <meta name="twitter:image" content="https://documate.work/og.jpg">
 
   <!-- Favicon -->
   <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>📄</text></svg>">
 
   <!-- JSON-LD Organization (static) -->
   <script type="application/ld+json">
-  {"@context":"https://schema.org","@type":"Organization","name":"DocuMate","url":"https://documate-pi.vercel.app/","logo":"https://documate-pi.vercel.app/og.jpg"}
+  {"@context":"https://schema.org","@type":"Organization","name":"DocuMate","url":"https://documate.work/","logo":"https://documate.work/og.jpg"}
   </script>
   <!-- JSON-LD WebSite (lang is updated at runtime) -->
-  <script type="application/ld+json" id="jsonld-website">{"@context":"https://schema.org","@type":"WebSite","name":"DocuMate","url":"https://documate-pi.vercel.app/","inLanguage":"en","description":"Explain contracts, bills & official documents in plain language."}</script>
+  <script type="application/ld+json" id="jsonld-website">{"@context":"https://schema.org","@type":"WebSite","name":"DocuMate","url":"https://documate.work/","inLanguage":"en","description":"Explain contracts, bills & official documents in plain language."}</script>
 
   <!-- PDF.js & Mammoth.js (DOCX) -->
   <script src="https://unpkg.com/pdfjs-dist@4.7.76/build/pdf.min.js"></script>
@@ -289,7 +289,7 @@
       document.title = L.htmlTitle;
       $('#meta-title').textContent = L.htmlTitle;
       $('#meta-desc')?.setAttribute('content', L.htmlDesc);
-      const base = 'https://documate-pi.vercel.app';
+      const base = 'https://documate.work';
       const path = LANG_PATH[lang] || '/';
       $('#link-canonical')?.setAttribute('href', base + path);
       $('#og-url')?.setAttribute('content', base + path);
@@ -299,7 +299,7 @@
       $('#tw-desc')?.setAttribute('content', L.htmlDesc);
 
       // JSON-LD website
-      const ld = {"@context":"https://schema.org","@type":"WebSite","name":"DocuMate","url":"https://documate-pi.vercel.app/","inLanguage":lang,"description":L.htmlDesc};
+      const ld = {"@context":"https://schema.org","@type":"WebSite","name":"DocuMate","url":"https://documate.work/","inLanguage":lang,"description":L.htmlDesc};
       $('#jsonld-website').textContent = JSON.stringify(ld);
 
       // Update select value label text (keep options static)

--- a/robots.txt
+++ b/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://documate-pi.vercel.app/sitemap.xml
+Sitemap: https://documate.work/sitemap.xml

--- a/ru/index.html
+++ b/ru/index.html
@@ -6,49 +6,49 @@
   <meta name="robots" content="index,follow" />
 
   <!-- Google Search Console -->
-  <meta name="google-site-verification" content="yHzn771ZljIbFj8wJJlnJ2FVIw9YjW1w0EJlZImH0QA" />
+  <meta name="google-site-verification" content="NOUVEAU_TOKEN_DOCUMATE_WORK" />
 
   <!-- AdSense global (keep once per page) -->
   <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9411950027978678" crossorigin="anonymous"></script>
 
   <title id="meta-title">DocuMate — Understand your documents easily</title>
   <meta id="meta-desc" name="description" content="DocuMate explains contracts, bills and official documents in plain language. Free, private, multilingual.">
-  <link id="link-canonical" rel="canonical" href="https://documate-pi.vercel.app/" />
+  <link id="link-canonical" rel="canonical" href="https://documate.work/ru/" />
 
   <!-- Hreflang (static full set) -->
-  <link rel="alternate" hreflang="x-default" href="https://documate-pi.vercel.app/">
-  <link rel="alternate" hreflang="en" href="https://documate-pi.vercel.app/">
-  <link rel="alternate" hreflang="fr" href="https://documate-pi.vercel.app/fr/">
-  <link rel="alternate" hreflang="de" href="https://documate-pi.vercel.app/de/">
-  <link rel="alternate" hreflang="es" href="https://documate-pi.vercel.app/es/">
-  <link rel="alternate" hreflang="it" href="https://documate-pi.vercel.app/it/">
-  <link rel="alternate" hreflang="zh" href="https://documate-pi.vercel.app/zh/">
-  <link rel="alternate" hreflang="hi" href="https://documate-pi.vercel.app/hi/">
-  <link rel="alternate" hreflang="ar" href="https://documate-pi.vercel.app/ar/">
-  <link rel="alternate" hreflang="pt" href="https://documate-pi.vercel.app/pt/">
-  <link rel="alternate" hreflang="ru" href="https://documate-pi.vercel.app/ru/">
-  <link rel="alternate" hreflang="bn" href="https://documate-pi.vercel.app/bn/">
+  <link rel="alternate" hreflang="x-default" href="https://documate.work/">
+  <link rel="alternate" hreflang="en" href="https://documate.work/">
+  <link rel="alternate" hreflang="fr" href="https://documate.work/fr/">
+  <link rel="alternate" hreflang="de" href="https://documate.work/de/">
+  <link rel="alternate" hreflang="es" href="https://documate.work/es/">
+  <link rel="alternate" hreflang="it" href="https://documate.work/it/">
+  <link rel="alternate" hreflang="zh" href="https://documate.work/zh/">
+  <link rel="alternate" hreflang="hi" href="https://documate.work/hi/">
+  <link rel="alternate" hreflang="ar" href="https://documate.work/ar/">
+  <link rel="alternate" hreflang="pt" href="https://documate.work/pt/">
+  <link rel="alternate" hreflang="ru" href="https://documate.work/ru/">
+  <link rel="alternate" hreflang="bn" href="https://documate.work/bn/">
 
   <!-- Open Graph / Twitter, will be rewritten by JS on load -->
   <meta property="og:type" content="website">
-  <meta id="og-url" property="og:url" content="https://documate-pi.vercel.app/">
+  <meta id="og-url" property="og:url" content="https://documate.work/ru/">
   <meta id="og-title" property="og:title" content="DocuMate — Understand your documents easily">
   <meta id="og-desc" property="og:description" content="Explain contracts, bills & official documents in plain language. Free, private, multilingual.">
-  <meta property="og:image" content="https://documate-pi.vercel.app/og.jpg">
+  <meta property="og:image" content="https://documate.work/og.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta id="tw-title" name="twitter:title" content="DocuMate — Understand your documents easily">
   <meta id="tw-desc" name="twitter:description" content="Explain contracts, bills & official documents in plain language. Free, private, multilingual.">
-  <meta name="twitter:image" content="https://documate-pi.vercel.app/og.jpg">
+  <meta name="twitter:image" content="https://documate.work/og.jpg">
 
   <!-- Favicon -->
   <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>📄</text></svg>">
 
   <!-- JSON-LD Organization (static) -->
   <script type="application/ld+json">
-  {"@context":"https://schema.org","@type":"Organization","name":"DocuMate","url":"https://documate-pi.vercel.app/","logo":"https://documate-pi.vercel.app/og.jpg"}
+  {"@context":"https://schema.org","@type":"Organization","name":"DocuMate","url":"https://documate.work/","logo":"https://documate.work/og.jpg"}
   </script>
   <!-- JSON-LD WebSite (lang is updated at runtime) -->
-  <script type="application/ld+json" id="jsonld-website">{"@context":"https://schema.org","@type":"WebSite","name":"DocuMate","url":"https://documate-pi.vercel.app/","inLanguage":"en","description":"Explain contracts, bills & official documents in plain language."}</script>
+  <script type="application/ld+json" id="jsonld-website">{"@context":"https://schema.org","@type":"WebSite","name":"DocuMate","url":"https://documate.work/","inLanguage":"en","description":"Explain contracts, bills & official documents in plain language."}</script>
 
   <!-- PDF.js & Mammoth.js (DOCX) -->
   <script src="https://unpkg.com/pdfjs-dist@4.7.76/build/pdf.min.js"></script>
@@ -289,7 +289,7 @@
       document.title = L.htmlTitle;
       $('#meta-title').textContent = L.htmlTitle;
       $('#meta-desc')?.setAttribute('content', L.htmlDesc);
-      const base = 'https://documate-pi.vercel.app';
+      const base = 'https://documate.work';
       const path = LANG_PATH[lang] || '/';
       $('#link-canonical')?.setAttribute('href', base + path);
       $('#og-url')?.setAttribute('content', base + path);
@@ -299,7 +299,7 @@
       $('#tw-desc')?.setAttribute('content', L.htmlDesc);
 
       // JSON-LD website
-      const ld = {"@context":"https://schema.org","@type":"WebSite","name":"DocuMate","url":"https://documate-pi.vercel.app/","inLanguage":lang,"description":L.htmlDesc};
+      const ld = {"@context":"https://schema.org","@type":"WebSite","name":"DocuMate","url":"https://documate.work/","inLanguage":lang,"description":L.htmlDesc};
       $('#jsonld-website').textContent = JSON.stringify(ld);
 
       // Update select value label text (keep options static)

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <url><loc>https://documate-pi.vercel.app/</loc><lastmod>2025-09-02</lastmod></url>
-  <url><loc>https://documate-pi.vercel.app/fr/</loc><lastmod>2025-09-02</lastmod></url>
-  <url><loc>https://documate-pi.vercel.app/de/</loc><lastmod>2025-09-02</lastmod></url>
-  <url><loc>https://documate-pi.vercel.app/es/</loc><lastmod>2025-09-02</lastmod></url>
-  <url><loc>https://documate-pi.vercel.app/it/</loc><lastmod>2025-09-02</lastmod></url>
-  <url><loc>https://documate-pi.vercel.app/zh/</loc><lastmod>2025-09-02</lastmod></url>
-  <url><loc>https://documate-pi.vercel.app/hi/</loc><lastmod>2025-09-02</lastmod></url>
-  <url><loc>https://documate-pi.vercel.app/ar/</loc><lastmod>2025-09-02</lastmod></url>
-  <url><loc>https://documate-pi.vercel.app/pt/</loc><lastmod>2025-09-02</lastmod></url>
-  <url><loc>https://documate-pi.vercel.app/ru/</loc><lastmod>2025-09-02</lastmod></url>
-  <url><loc>https://documate-pi.vercel.app/bn/</loc><lastmod>2025-09-02</lastmod></url>
+  <url><loc>https://documate.work/</loc><lastmod>2025-09-02</lastmod></url>
+  <url><loc>https://documate.work/fr/</loc><lastmod>2025-09-02</lastmod></url>
+  <url><loc>https://documate.work/de/</loc><lastmod>2025-09-02</lastmod></url>
+  <url><loc>https://documate.work/es/</loc><lastmod>2025-09-02</lastmod></url>
+  <url><loc>https://documate.work/it/</loc><lastmod>2025-09-02</lastmod></url>
+  <url><loc>https://documate.work/zh/</loc><lastmod>2025-09-02</lastmod></url>
+  <url><loc>https://documate.work/hi/</loc><lastmod>2025-09-02</lastmod></url>
+  <url><loc>https://documate.work/ar/</loc><lastmod>2025-09-02</lastmod></url>
+  <url><loc>https://documate.work/pt/</loc><lastmod>2025-09-02</lastmod></url>
+  <url><loc>https://documate.work/ru/</loc><lastmod>2025-09-02</lastmod></url>
+  <url><loc>https://documate.work/bn/</loc><lastmod>2025-09-02</lastmod></url>
 </urlset>

--- a/zh/index.html
+++ b/zh/index.html
@@ -6,49 +6,49 @@
   <meta name="robots" content="index,follow" />
 
   <!-- Google Search Console -->
-  <meta name="google-site-verification" content="yHzn771ZljIbFj8wJJlnJ2FVIw9YjW1w0EJlZImH0QA" />
+  <meta name="google-site-verification" content="NOUVEAU_TOKEN_DOCUMATE_WORK" />
 
   <!-- AdSense global (keep once per page) -->
   <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9411950027978678" crossorigin="anonymous"></script>
 
   <title id="meta-title">DocuMate — Understand your documents easily</title>
   <meta id="meta-desc" name="description" content="DocuMate explains contracts, bills and official documents in plain language. Free, private, multilingual.">
-  <link id="link-canonical" rel="canonical" href="https://documate-pi.vercel.app/" />
+  <link id="link-canonical" rel="canonical" href="https://documate.work/zh/" />
 
   <!-- Hreflang (static full set) -->
-  <link rel="alternate" hreflang="x-default" href="https://documate-pi.vercel.app/">
-  <link rel="alternate" hreflang="en" href="https://documate-pi.vercel.app/">
-  <link rel="alternate" hreflang="fr" href="https://documate-pi.vercel.app/fr/">
-  <link rel="alternate" hreflang="de" href="https://documate-pi.vercel.app/de/">
-  <link rel="alternate" hreflang="es" href="https://documate-pi.vercel.app/es/">
-  <link rel="alternate" hreflang="it" href="https://documate-pi.vercel.app/it/">
-  <link rel="alternate" hreflang="zh" href="https://documate-pi.vercel.app/zh/">
-  <link rel="alternate" hreflang="hi" href="https://documate-pi.vercel.app/hi/">
-  <link rel="alternate" hreflang="ar" href="https://documate-pi.vercel.app/ar/">
-  <link rel="alternate" hreflang="pt" href="https://documate-pi.vercel.app/pt/">
-  <link rel="alternate" hreflang="ru" href="https://documate-pi.vercel.app/ru/">
-  <link rel="alternate" hreflang="bn" href="https://documate-pi.vercel.app/bn/">
+  <link rel="alternate" hreflang="x-default" href="https://documate.work/">
+  <link rel="alternate" hreflang="en" href="https://documate.work/">
+  <link rel="alternate" hreflang="fr" href="https://documate.work/fr/">
+  <link rel="alternate" hreflang="de" href="https://documate.work/de/">
+  <link rel="alternate" hreflang="es" href="https://documate.work/es/">
+  <link rel="alternate" hreflang="it" href="https://documate.work/it/">
+  <link rel="alternate" hreflang="zh" href="https://documate.work/zh/">
+  <link rel="alternate" hreflang="hi" href="https://documate.work/hi/">
+  <link rel="alternate" hreflang="ar" href="https://documate.work/ar/">
+  <link rel="alternate" hreflang="pt" href="https://documate.work/pt/">
+  <link rel="alternate" hreflang="ru" href="https://documate.work/ru/">
+  <link rel="alternate" hreflang="bn" href="https://documate.work/bn/">
 
   <!-- Open Graph / Twitter, will be rewritten by JS on load -->
   <meta property="og:type" content="website">
-  <meta id="og-url" property="og:url" content="https://documate-pi.vercel.app/">
+  <meta id="og-url" property="og:url" content="https://documate.work/zh/">
   <meta id="og-title" property="og:title" content="DocuMate — Understand your documents easily">
   <meta id="og-desc" property="og:description" content="Explain contracts, bills & official documents in plain language. Free, private, multilingual.">
-  <meta property="og:image" content="https://documate-pi.vercel.app/og.jpg">
+  <meta property="og:image" content="https://documate.work/og.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta id="tw-title" name="twitter:title" content="DocuMate — Understand your documents easily">
   <meta id="tw-desc" name="twitter:description" content="Explain contracts, bills & official documents in plain language. Free, private, multilingual.">
-  <meta name="twitter:image" content="https://documate-pi.vercel.app/og.jpg">
+  <meta name="twitter:image" content="https://documate.work/og.jpg">
 
   <!-- Favicon -->
   <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>📄</text></svg>">
 
   <!-- JSON-LD Organization (static) -->
   <script type="application/ld+json">
-  {"@context":"https://schema.org","@type":"Organization","name":"DocuMate","url":"https://documate-pi.vercel.app/","logo":"https://documate-pi.vercel.app/og.jpg"}
+  {"@context":"https://schema.org","@type":"Organization","name":"DocuMate","url":"https://documate.work/","logo":"https://documate.work/og.jpg"}
   </script>
   <!-- JSON-LD WebSite (lang is updated at runtime) -->
-  <script type="application/ld+json" id="jsonld-website">{"@context":"https://schema.org","@type":"WebSite","name":"DocuMate","url":"https://documate-pi.vercel.app/","inLanguage":"en","description":"Explain contracts, bills & official documents in plain language."}</script>
+  <script type="application/ld+json" id="jsonld-website">{"@context":"https://schema.org","@type":"WebSite","name":"DocuMate","url":"https://documate.work/","inLanguage":"en","description":"Explain contracts, bills & official documents in plain language."}</script>
 
   <!-- PDF.js & Mammoth.js (DOCX) -->
   <script src="https://unpkg.com/pdfjs-dist@4.7.76/build/pdf.min.js"></script>
@@ -289,7 +289,7 @@
       document.title = L.htmlTitle;
       $('#meta-title').textContent = L.htmlTitle;
       $('#meta-desc')?.setAttribute('content', L.htmlDesc);
-      const base = 'https://documate-pi.vercel.app';
+      const base = 'https://documate.work';
       const path = LANG_PATH[lang] || '/';
       $('#link-canonical')?.setAttribute('href', base + path);
       $('#og-url')?.setAttribute('content', base + path);
@@ -299,7 +299,7 @@
       $('#tw-desc')?.setAttribute('content', L.htmlDesc);
 
       // JSON-LD website
-      const ld = {"@context":"https://schema.org","@type":"WebSite","name":"DocuMate","url":"https://documate-pi.vercel.app/","inLanguage":lang,"description":L.htmlDesc};
+      const ld = {"@context":"https://schema.org","@type":"WebSite","name":"DocuMate","url":"https://documate.work/","inLanguage":lang,"description":L.htmlDesc};
       $('#jsonld-website').textContent = JSON.stringify(ld);
 
       // Update select value label text (keep options static)


### PR DESCRIPTION
## Summary
- Replace all SEO domains with `https://documate.work`
- Update localized canonical and Open Graph URLs
- Refresh Search Console token and sitemap links

## Testing
- `grep -R "documate-pi.vercel.app" -n .`

------
https://chatgpt.com/codex/tasks/task_e_68b9720c0f908329b8552dac492f44eb