### PR TITLE
chore(license): add SA-NC 1.0 license and apply SPDX headers

### DIFF
--- a/.github/workflows/spdx-check.yml
+++ b/.github/workflows/spdx-check.yml
@@ -1,0 +1,22 @@
+name: SPDX check
+on: [push, pull_request]
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Ensure SPDX headers
+        run: |
+          set -e
+          MISS=0
+          while IFS= read -r -d '' f; do
+            case "$f" in
+              */node_modules/*|*/vendor/*|*/dist/*|*/build/*) continue;;
+              *.html|*.js|*.css) ;;
+              *) continue;;
+            esac
+            if ! grep -q "SPDX-License-Identifier: LicenseRef-SA-NC-1.0" "$f"; then
+              echo "Missing SPDX in $f"; MISS=1
+            fi
+          done < <(find . -type f -print0)
+          exit $MISS

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,19 @@
+DocuMate Non-Commercial Share-Alike License 1.0
+SPDX-License-Identifier: LicenseRef-SA-NC-1.0
+
+Copyright (c) 2025 [TON ORGANISATION]
+
+1) Permissions
+- Use, copy, and modify for NON-COMMERCIAL purposes only.
+- You must keep this license text and copyright notices.
+- If you distribute modified or unmodified versions, you MUST license them under the same terms (Share-Alike) and include clear attribution to “[TON ORGANISATION] — DocuMate”.
+
+2) Prohibitions
+- No commercial use (including selling, ad-supported redistribution, SaaS resale) without a separate written license.
+- No trademark rights are granted (names, logos remain the owner’s).
+
+3) Liability
+- Provided “AS IS”, without warranty. No liability for damages.
+
+4) Contact
+- For commercial licensing, contact: you@example.com

--- a/api/explain.js
+++ b/api/explain.js
@@ -1,3 +1,7 @@
+/*!
+ * Copyright (c) 2025 [TON ORGANISATION]
+ * SPDX-License-Identifier: LicenseRef-SA-NC-1.0
+ */
 // api/explain.js
 import OpenAI from "openai";
 

--- a/ar/index.html
+++ b/ar/index.html
@@ -1,3 +1,7 @@
+<!--
+  Copyright (c) 2025 [TON ORGANISATION]
+  SPDX-License-Identifier: LicenseRef-SA-NC-1.0
+-->
 <!doctype html>
 <html lang="en">
 <head>

--- a/bn/index.html
+++ b/bn/index.html
@@ -1,3 +1,7 @@
+<!--
+  Copyright (c) 2025 [TON ORGANISATION]
+  SPDX-License-Identifier: LicenseRef-SA-NC-1.0
+-->
 <!doctype html>
 <html lang="en">
 <head>

--- a/de/index.html
+++ b/de/index.html
@@ -1,3 +1,7 @@
+<!--
+  Copyright (c) 2025 [TON ORGANISATION]
+  SPDX-License-Identifier: LicenseRef-SA-NC-1.0
+-->
 <!doctype html>
 <html lang="en">
 <head>

--- a/en/index.html
+++ b/en/index.html
@@ -1,3 +1,7 @@
+<!--
+  Copyright (c) 2025 [TON ORGANISATION]
+  SPDX-License-Identifier: LicenseRef-SA-NC-1.0
+-->
 <!doctype html>
 <html lang="en">
 <head>

--- a/es/index.html
+++ b/es/index.html
@@ -1,3 +1,7 @@
+<!--
+  Copyright (c) 2025 [TON ORGANISATION]
+  SPDX-License-Identifier: LicenseRef-SA-NC-1.0
+-->
 <!doctype html>
 <html lang="en">
 <head>

--- a/fr/index.html
+++ b/fr/index.html
@@ -1,3 +1,7 @@
+<!--
+  Copyright (c) 2025 [TON ORGANISATION]
+  SPDX-License-Identifier: LicenseRef-SA-NC-1.0
+-->
 <!doctype html>
 <html lang="en">
 <head>

--- a/google7fba15cbdb4cbaf7.html
+++ b/google7fba15cbdb4cbaf7.html
@@ -1,1 +1,5 @@
+<!--
+  Copyright (c) 2025 [TON ORGANISATION]
+  SPDX-License-Identifier: LicenseRef-SA-NC-1.0
+-->
 google-site-verification: google7fba15cbdb4cbaf7.html

--- a/hi/index.html
+++ b/hi/index.html
@@ -1,3 +1,7 @@
+<!--
+  Copyright (c) 2025 [TON ORGANISATION]
+  SPDX-License-Identifier: LicenseRef-SA-NC-1.0
+-->
 <!doctype html>
 <html lang="en">
 <head>

--- a/index.html
+++ b/index.html
@@ -1,3 +1,7 @@
+<!--
+  Copyright (c) 2025 [TON ORGANISATION]
+  SPDX-License-Identifier: LicenseRef-SA-NC-1.0
+-->
 <!doctype html>
 <html lang="en">
 <head>

--- a/it/index.html
+++ b/it/index.html
@@ -1,3 +1,7 @@
+<!--
+  Copyright (c) 2025 [TON ORGANISATION]
+  SPDX-License-Identifier: LicenseRef-SA-NC-1.0
+-->
 <!doctype html>
 <html lang="en">
 <head>

--- a/privacy.html
+++ b/privacy.html
@@ -1,3 +1,7 @@
+<!--
+  Copyright (c) 2025 [TON ORGANISATION]
+  SPDX-License-Identifier: LicenseRef-SA-NC-1.0
+-->
 <!doctype html>
 <html lang="fr">
 <head>

--- a/pt/index.html
+++ b/pt/index.html
@@ -1,3 +1,7 @@
+<!--
+  Copyright (c) 2025 [TON ORGANISATION]
+  SPDX-License-Identifier: LicenseRef-SA-NC-1.0
+-->
 <!doctype html>
 <html lang="en">
 <head>

--- a/ru/index.html
+++ b/ru/index.html
@@ -1,3 +1,7 @@
+<!--
+  Copyright (c) 2025 [TON ORGANISATION]
+  SPDX-License-Identifier: LicenseRef-SA-NC-1.0
+-->
 <!doctype html>
 <html lang="en">
 <head>

--- a/scripts/apply-spdx.js
+++ b/scripts/apply-spdx.js
@@ -1,0 +1,57 @@
+// scripts/apply-spdx.js
+// Usage: node scripts/apply-spdx.js "[TON ORGANISATION]"
+
+const fs = require('fs');
+const path = require('path');
+const ORG = process.argv[2] || '[TON ORGANISATION]';
+const YEAR = '2025';
+const IGNORE_DIRS = new Set(['node_modules','vendor','dist','build','.git']);
+const HTML_HEADER =
+  `<!--\n  Copyright (c) ${YEAR} ${ORG}\n  SPDX-License-Identifier: LicenseRef-SA-NC-1.0
+const JS_HEADER =
+  `/*!\n * Copyright (c) ${YEAR} ${ORG}\n * SPDX-License-Identifier: LicenseRef-SA-NC-1.0
+
+function shouldIgnore(file) {
+  const rel = path.relative(process.cwd(), file).replace(/\\/g,'/');
+  if (rel.split('/').some(d => IGNORE_DIRS.has(d))) return true;
+  const lower = rel.toLowerCase();
+  if (/\.(png|jpg|jpeg|gif|webp|svg|pdf|woff2?|ttf|eot|mp4|webm|zip|gz|br)$/.test(lower)) return true;
+  return false;
+}
+
+function applyHeader(file) {
+  if (shouldIgnore(file)) return;
+  const ext = path.extname(file).toLowerCase();
+  if (!['.html','.js','.css'].includes(ext)) return;
+  let src = fs.readFileSync(file, 'utf8');
+
+  // Normaliser fins de ligne
+  src = src.replace(/\r\n/g, '\n');
+
+  // Si déjà SPDX → remplace la ligne entière
+  if (/SPDX-License-Identifier: LicenseRef-SA-NC-1.0
+    src = src.replace(/SPDX-License-Identifier: LicenseRef-SA-NC-1.0
+    src = src.replace(/Copyright \(c\) \d{4} .*?/g, `Copyright (c) ${YEAR} ${ORG}`);
+    fs.writeFileSync(file, src);
+    return;
+  }
+
+  // Sinon, préfixer selon type
+  const header = (ext === '.html') ? HTML_HEADER : JS_HEADER;
+  fs.writeFileSync(file, header + src);
+}
+
+function walk(dir) {
+  for (const name of fs.readdirSync(dir)) {
+    const p = path.join(dir, name);
+    const stat = fs.lstatSync(p);
+    if (stat.isDirectory()) {
+      if (!IGNORE_DIRS.has(name)) walk(p);
+    } else if (stat.isFile()) {
+      applyHeader(p);
+    }
+  }
+}
+
+walk(process.cwd());
+console.log('SPDX headers applied.');

--- a/zh/index.html
+++ b/zh/index.html
@@ -1,3 +1,7 @@
+<!--
+  Copyright (c) 2025 [TON ORGANISATION]
+  SPDX-License-Identifier: LicenseRef-SA-NC-1.0
+-->
 <!doctype html>
 <html lang="en">
 <head>


### PR DESCRIPTION
## Summary
- add SA-NC 1.0 LICENSE file
- add script and workflow to enforce SPDX LicenseRef-SA-NC-1.0 headers
- apply SPDX headers to HTML/JS sources

## Testing
- `node scripts/apply-spdx.cjs "[TON ORGANISATION]"` *(during development)*
- `bash -lc 'set -e; MISS=0; while IFS= read -r -d "" f; do case "$f" in */node_modules/*|*/vendor/*|*/dist/*|*/build/*) continue;; *.html|*.js|*.css) ;; *) continue;; esac; if ! grep -q "SPDX-License-Identifier: LicenseRef-SA-NC-1.0" "$f"; then echo "Missing SPDX in $f"; MISS=1; fi; done < <(find . -type f -print0); exit $MISS'`
- `npm test` *(fails: Missing script: "test"\*)


------
https://chatgpt.com/codex/tasks/task_e_68b9751e8fbc8329ae1d33270c40e794