### PR TITLE
Add reopen button for privacy panel

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -652,11 +652,13 @@ body.sidebar-collapsed .show-sidebar-btn{ display:inline-block; }
   function apply(collapsed){
     if(collapsed){
       body.classList.add('sidebar-collapsed');
-      showBtn.hidden = false;
+      showBtn.removeAttribute('hidden');
+      showBtn.setAttribute('aria-expanded','false');
       hideBtn.setAttribute('aria-expanded','false');
     }else{
       body.classList.remove('sidebar-collapsed');
-      showBtn.hidden = true;
+      showBtn.setAttribute('hidden','');
+      showBtn.setAttribute('aria-expanded','true');
       hideBtn.setAttribute('aria-expanded','true');
     }
     try{ localStorage.setItem(KEY, collapsed ? '1' : '0'); }catch(e){}

--- a/bn/index.html
+++ b/bn/index.html
@@ -652,11 +652,13 @@ body.sidebar-collapsed .show-sidebar-btn{ display:inline-block; }
   function apply(collapsed){
     if(collapsed){
       body.classList.add('sidebar-collapsed');
-      showBtn.hidden = false;
+      showBtn.removeAttribute('hidden');
+      showBtn.setAttribute('aria-expanded','false');
       hideBtn.setAttribute('aria-expanded','false');
     }else{
       body.classList.remove('sidebar-collapsed');
-      showBtn.hidden = true;
+      showBtn.setAttribute('hidden','');
+      showBtn.setAttribute('aria-expanded','true');
       hideBtn.setAttribute('aria-expanded','true');
     }
     try{ localStorage.setItem(KEY, collapsed ? '1' : '0'); }catch(e){}

--- a/de/index.html
+++ b/de/index.html
@@ -652,11 +652,13 @@ body.sidebar-collapsed .show-sidebar-btn{ display:inline-block; }
   function apply(collapsed){
     if(collapsed){
       body.classList.add('sidebar-collapsed');
-      showBtn.hidden = false;
+      showBtn.removeAttribute('hidden');
+      showBtn.setAttribute('aria-expanded','false');
       hideBtn.setAttribute('aria-expanded','false');
     }else{
       body.classList.remove('sidebar-collapsed');
-      showBtn.hidden = true;
+      showBtn.setAttribute('hidden','');
+      showBtn.setAttribute('aria-expanded','true');
       hideBtn.setAttribute('aria-expanded','true');
     }
     try{ localStorage.setItem(KEY, collapsed ? '1' : '0'); }catch(e){}

--- a/es/index.html
+++ b/es/index.html
@@ -652,11 +652,13 @@ body.sidebar-collapsed .show-sidebar-btn{ display:inline-block; }
   function apply(collapsed){
     if(collapsed){
       body.classList.add('sidebar-collapsed');
-      showBtn.hidden = false;
+      showBtn.removeAttribute('hidden');
+      showBtn.setAttribute('aria-expanded','false');
       hideBtn.setAttribute('aria-expanded','false');
     }else{
       body.classList.remove('sidebar-collapsed');
-      showBtn.hidden = true;
+      showBtn.setAttribute('hidden','');
+      showBtn.setAttribute('aria-expanded','true');
       hideBtn.setAttribute('aria-expanded','true');
     }
     try{ localStorage.setItem(KEY, collapsed ? '1' : '0'); }catch(e){}

--- a/fr/index.html
+++ b/fr/index.html
@@ -652,11 +652,13 @@ body.sidebar-collapsed .show-sidebar-btn{ display:inline-block; }
   function apply(collapsed){
     if(collapsed){
       body.classList.add('sidebar-collapsed');
-      showBtn.hidden = false;
+      showBtn.removeAttribute('hidden');
+      showBtn.setAttribute('aria-expanded','false');
       hideBtn.setAttribute('aria-expanded','false');
     }else{
       body.classList.remove('sidebar-collapsed');
-      showBtn.hidden = true;
+      showBtn.setAttribute('hidden','');
+      showBtn.setAttribute('aria-expanded','true');
       hideBtn.setAttribute('aria-expanded','true');
     }
     try{ localStorage.setItem(KEY, collapsed ? '1' : '0'); }catch(e){}

--- a/hi/index.html
+++ b/hi/index.html
@@ -652,11 +652,13 @@ body.sidebar-collapsed .show-sidebar-btn{ display:inline-block; }
   function apply(collapsed){
     if(collapsed){
       body.classList.add('sidebar-collapsed');
-      showBtn.hidden = false;
+      showBtn.removeAttribute('hidden');
+      showBtn.setAttribute('aria-expanded','false');
       hideBtn.setAttribute('aria-expanded','false');
     }else{
       body.classList.remove('sidebar-collapsed');
-      showBtn.hidden = true;
+      showBtn.setAttribute('hidden','');
+      showBtn.setAttribute('aria-expanded','true');
       hideBtn.setAttribute('aria-expanded','true');
     }
     try{ localStorage.setItem(KEY, collapsed ? '1' : '0'); }catch(e){}

--- a/index.html
+++ b/index.html
@@ -652,11 +652,13 @@ body.sidebar-collapsed .show-sidebar-btn{ display:inline-block; }
   function apply(collapsed){
     if(collapsed){
       body.classList.add('sidebar-collapsed');
-      showBtn.hidden = false;
+      showBtn.removeAttribute('hidden');
+      showBtn.setAttribute('aria-expanded','false');
       hideBtn.setAttribute('aria-expanded','false');
     }else{
       body.classList.remove('sidebar-collapsed');
-      showBtn.hidden = true;
+      showBtn.setAttribute('hidden','');
+      showBtn.setAttribute('aria-expanded','true');
       hideBtn.setAttribute('aria-expanded','true');
     }
     try{ localStorage.setItem(KEY, collapsed ? '1' : '0'); }catch(e){}

--- a/it/index.html
+++ b/it/index.html
@@ -652,11 +652,13 @@ body.sidebar-collapsed .show-sidebar-btn{ display:inline-block; }
   function apply(collapsed){
     if(collapsed){
       body.classList.add('sidebar-collapsed');
-      showBtn.hidden = false;
+      showBtn.removeAttribute('hidden');
+      showBtn.setAttribute('aria-expanded','false');
       hideBtn.setAttribute('aria-expanded','false');
     }else{
       body.classList.remove('sidebar-collapsed');
-      showBtn.hidden = true;
+      showBtn.setAttribute('hidden','');
+      showBtn.setAttribute('aria-expanded','true');
       hideBtn.setAttribute('aria-expanded','true');
     }
     try{ localStorage.setItem(KEY, collapsed ? '1' : '0'); }catch(e){}

--- a/pt/index.html
+++ b/pt/index.html
@@ -652,11 +652,13 @@ body.sidebar-collapsed .show-sidebar-btn{ display:inline-block; }
   function apply(collapsed){
     if(collapsed){
       body.classList.add('sidebar-collapsed');
-      showBtn.hidden = false;
+      showBtn.removeAttribute('hidden');
+      showBtn.setAttribute('aria-expanded','false');
       hideBtn.setAttribute('aria-expanded','false');
     }else{
       body.classList.remove('sidebar-collapsed');
-      showBtn.hidden = true;
+      showBtn.setAttribute('hidden','');
+      showBtn.setAttribute('aria-expanded','true');
       hideBtn.setAttribute('aria-expanded','true');
     }
     try{ localStorage.setItem(KEY, collapsed ? '1' : '0'); }catch(e){}

--- a/ru/index.html
+++ b/ru/index.html
@@ -652,11 +652,13 @@ body.sidebar-collapsed .show-sidebar-btn{ display:inline-block; }
   function apply(collapsed){
     if(collapsed){
       body.classList.add('sidebar-collapsed');
-      showBtn.hidden = false;
+      showBtn.removeAttribute('hidden');
+      showBtn.setAttribute('aria-expanded','false');
       hideBtn.setAttribute('aria-expanded','false');
     }else{
       body.classList.remove('sidebar-collapsed');
-      showBtn.hidden = true;
+      showBtn.setAttribute('hidden','');
+      showBtn.setAttribute('aria-expanded','true');
       hideBtn.setAttribute('aria-expanded','true');
     }
     try{ localStorage.setItem(KEY, collapsed ? '1' : '0'); }catch(e){}

--- a/zh/index.html
+++ b/zh/index.html
@@ -652,11 +652,13 @@ body.sidebar-collapsed .show-sidebar-btn{ display:inline-block; }
   function apply(collapsed){
     if(collapsed){
       body.classList.add('sidebar-collapsed');
-      showBtn.hidden = false;
+      showBtn.removeAttribute('hidden');
+      showBtn.setAttribute('aria-expanded','false');
       hideBtn.setAttribute('aria-expanded','false');
     }else{
       body.classList.remove('sidebar-collapsed');
-      showBtn.hidden = true;
+      showBtn.setAttribute('hidden','');
+      showBtn.setAttribute('aria-expanded','true');
       hideBtn.setAttribute('aria-expanded','true');
     }
     try{ localStorage.setItem(KEY, collapsed ? '1' : '0'); }catch(e){}


### PR DESCRIPTION
## Summary
- Display a floating button when the privacy sidebar is hidden so users can reopen it
- Apply the fix across all localized index pages

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b98a5d27d48329a7029040d4e0dd52