### PR TITLE
fix(spdx+i18n): add SPDX header to lang-switch.js and enable real language redirect

### DIFF
--- a/public/scripts/lang-switch.js
+++ b/public/scripts/lang-switch.js
@@ -1,19 +1,24 @@
-(function(){
-  const sel = document.getElementById('langSel');
+/* SPDX-FileCopyrightText: 2025 DocExpain
+ * SPDX-License-Identifier: LicenseRef-SA-NC-1.0
+ */
+(function () {
+  var sel = document.getElementById('langSel');
   if (!sel) return;
 
-  // Cartographie : adapter EN selon l’option (A ou B)
-  const hasEnDir = !!document.querySelector('link[href="https://documate.work/en/"]');
-  const target = hasEnDir
-    ? { en:'/en/', fr:'/fr/', de:'/de/', es:'/es/', it:'/it/', pt:'/pt/', zh:'/zh/', hi:'/hi/', ar:'/ar/', ru:'/ru/', bn:'/bn/' }
-    : { en:'/',    fr:'/fr/', de:'/de/', es:'/es/', it:'/it/', pt:'/pt/', zh:'/zh/', hi:'/hi/', ar:'/ar/', ru:'/ru/', bn:'/bn/' };
+  // Détecte si la version EN est servie depuis /en/ via le bloc hreflang
+  var hasEnDir = !!document.querySelector('link[rel="alternate"][hreflang="en"][href$="/en/"]');
 
-  // Pré-sélection en fonction de <html lang="">
-  const pageLang = (document.documentElement.lang || 'en').toLowerCase();
+  var target = hasEnDir
+    ? { en: '/en/', fr: '/fr/', de: '/de/', es: '/es/', it: '/it/', pt: '/pt/', zh: '/zh/', hi: '/hi/', ar: '/ar/', ru: '/ru/', bn: '/bn/' }
+    : { en: '/',    fr: '/fr/', de: '/de/', es: '/es/', it: '/it/', pt: '/pt/', zh: '/zh/', hi: '/hi/', ar: '/ar/', ru: '/ru/', bn: '/bn/' };
+
+  // Pré-sélection selon <html lang="…">
+  var pageLang = (document.documentElement.lang || 'en').toLowerCase();
   if (target[pageLang]) sel.value = pageLang;
 
-  sel.addEventListener('change', function(){
-    const url = target[this.value] || '/';
-    if (location.pathname !== url) location.href = url; // REDIRECTION RÉELLE
+  // Redirection réelle (recharge la bonne URL de langue)
+  sel.addEventListener('change', function () {
+    var url = target[this.value] || '/';
+    if (location.pathname !== url) location.href = url;
   });
 })();


### PR DESCRIPTION
## Summary
- add SPDX header to language switcher and use pure JS redirect
- confirm lang-switch.js is included once per page across languages

## Testing
- `rg "SPDX-License-Identifier" -n | wc -l`
- `head -n 3 public/scripts/lang-switch.js`
- `rg -c '<script src="/scripts/lang-switch.js"' */index.html index.html`


------
https://chatgpt.com/codex/tasks/task_e_68bb2e33cad483298a88236c298f6b0f