### PR TITLE
fix(vercel): explicit rewrites for / and /:lang/ + add simple 404.html

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,31 @@
+<!--
+  SPDX-FileCopyrightText: 2025 DocExpain
+  SPDX-License-Identifier: LicenseRef-SA-NC-1.0
+-->
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Not Found — DocuMate</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>
+    body{margin:0;display:grid;place-items:center;height:100dvh;font:16px/1.5 system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;background:#f7f9fc;color:#0f172a}
+    .card{padding:24px 28px;background:#fff;border-radius:14px;box-shadow:0 10px 30px rgba(2,6,23,.08);max-width:560px}
+    h1{margin:0 0 6px;font-size:22px}
+    p{margin:0 0 12px;color:#475569}
+    a{color:#2563eb;text-decoration:none}
+  </style>
+</head>
+<body>
+  <div class="card">
+    <h1>404 — Page not found</h1>
+    <p>The page you’re looking for doesn’t exist.</p>
+    <p><a href="/">Go to homepage</a> ·
+      <a href="/fr/">FR</a> · <a href="/de/">DE</a> · <a href="/es/">ES</a> ·
+      <a href="/it/">IT</a> · <a href="/pt/">PT</a> · <a href="/zh/">ZH</a> ·
+      <a href="/hi/">HI</a> · <a href="/ar/">AR</a> · <a href="/ru/">RU</a> ·
+      <a href="/bn/">BN</a>
+    </p>
+  </div>
+</body>
+</html>

--- a/vercel.json
+++ b/vercel.json
@@ -1,16 +1,62 @@
 {
+  "version": 2,
   "trailingSlash": true,
   "cleanUrls": true,
+
   "redirects": [
-    { "source": "/en", "destination": "/", "permanent": true },
-    { "source": "/:lang", "destination": "/:lang/", "permanent": true }
+    { "source": "/en",  "destination": "/", "permanent": true },
+    { "source": "/en/", "destination": "/", "permanent": true }
   ],
+
+  "rewrites": [
+    { "source": "/", "destination": "/index.html" },
+
+    { "source": "/ar",  "destination": "/ar/index.html" },
+    { "source": "/ar/", "destination": "/ar/index.html" },
+
+    { "source": "/bn",  "destination": "/bn/index.html" },
+    { "source": "/bn/", "destination": "/bn/index.html" },
+
+    { "source": "/de",  "destination": "/de/index.html" },
+    { "source": "/de/", "destination": "/de/index.html" },
+
+    { "source": "/es",  "destination": "/es/index.html" },
+    { "source": "/es/", "destination": "/es/index.html" },
+
+    { "source": "/fr",  "destination": "/fr/index.html" },
+    { "source": "/fr/", "destination": "/fr/index.html" },
+
+    { "source": "/hi",  "destination": "/hi/index.html" },
+    { "source": "/hi/", "destination": "/hi/index.html" },
+
+    { "source": "/it",  "destination": "/it/index.html" },
+    { "source": "/it/", "destination": "/it/index.html" },
+
+    { "source": "/pt",  "destination": "/pt/index.html" },
+    { "source": "/pt/", "destination": "/pt/index.html" },
+
+    { "source": "/ru",  "destination": "/ru/index.html" },
+    { "source": "/ru/", "destination": "/ru/index.html" },
+
+    { "source": "/zh",  "destination": "/zh/index.html" },
+    { "source": "/zh/", "destination": "/zh/index.html" }
+  ],
+
   "headers": [
     {
-      "source": "/(sitemap.xml|robots.txt|site.webmanifest|favicon.ico|favicon-32.png|icon-192.png|apple-touch-icon.png)",
+      "source": "/(sitemap.xml|robots.txt|site.webmanifest|favicon.ico|favicon-32.png|icon-192.png|apple-touch-icon.png|ads.txt)",
       "headers": [
-        { "key": "Cache-Control", "value": "public, max-age=86400" }
+        { "key": "Cache-Control", "value": "public, max-age=3600" },
+        { "key": "Content-Type", "value": "text/plain; charset=utf-8" }
       ]
+    },
+    {
+      "source": "/site.webmanifest",
+      "headers": [{ "key": "Content-Type", "value": "application/manifest+json; charset=utf-8" }]
+    },
+    {
+      "source": "/sitemap.xml",
+      "headers": [{ "key": "Content-Type", "value": "application/xml; charset=utf-8" }]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- replace `vercel.json` with explicit rewrites so `/` and `/lang` paths map to their `index.html`
- add minimal `404.html` page with license header

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bb444cd4888329aad5553362e1e9e3