### PR TITLE
fix(i18n+manifest): guard-based label assignment to avoid invalid LHS; refresh manifest schema (icons 192/512)

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -318,8 +318,8 @@ body.sidebar-collapsed .show-sidebar-btn{ display:inline-block; }
       $('#btnExplainSel').textContent = L.btnExplainSel;
       $('#btnSave').textContent = L.btnSave;
       $('#btnLoad').textContent = L.btnLoad;
-      byId('btnChooseFile')?.textContent = T.chooseFile;
-      byId('btnUseCamera')?.textContent = T.useCamera;
+      var elCF = document.getElementById('btnChooseFile'); if (elCF) elCF.textContent = T.chooseFile;
+      var elUC = document.getElementById('btnUseCamera'); if (elUC) elUC.textContent = T.useCamera;
       $('#label-ask').textContent = L.askLabel;
       $('#question').placeholder = L.phQuestion;
       $('#btnAskSel').textContent = L.btnAskSel;

--- a/bn/index.html
+++ b/bn/index.html
@@ -318,8 +318,8 @@ body.sidebar-collapsed .show-sidebar-btn{ display:inline-block; }
       $('#btnExplainSel').textContent = L.btnExplainSel;
       $('#btnSave').textContent = L.btnSave;
       $('#btnLoad').textContent = L.btnLoad;
-      byId('btnChooseFile')?.textContent = T.chooseFile;
-      byId('btnUseCamera')?.textContent = T.useCamera;
+      var elCF = document.getElementById('btnChooseFile'); if (elCF) elCF.textContent = T.chooseFile;
+      var elUC = document.getElementById('btnUseCamera'); if (elUC) elUC.textContent = T.useCamera;
       $('#label-ask').textContent = L.askLabel;
       $('#question').placeholder = L.phQuestion;
       $('#btnAskSel').textContent = L.btnAskSel;

--- a/de/index.html
+++ b/de/index.html
@@ -318,8 +318,8 @@ body.sidebar-collapsed .show-sidebar-btn{ display:inline-block; }
       $('#btnExplainSel').textContent = L.btnExplainSel;
       $('#btnSave').textContent = L.btnSave;
       $('#btnLoad').textContent = L.btnLoad;
-      byId('btnChooseFile')?.textContent = T.chooseFile;
-      byId('btnUseCamera')?.textContent = T.useCamera;
+      var elCF = document.getElementById('btnChooseFile'); if (elCF) elCF.textContent = T.chooseFile;
+      var elUC = document.getElementById('btnUseCamera'); if (elUC) elUC.textContent = T.useCamera;
       $('#label-ask').textContent = L.askLabel;
       $('#question').placeholder = L.phQuestion;
       $('#btnAskSel').textContent = L.btnAskSel;

--- a/en/index.html
+++ b/en/index.html
@@ -318,8 +318,8 @@ body.sidebar-collapsed .show-sidebar-btn{ display:inline-block; }
       $('#btnExplainSel').textContent = L.btnExplainSel;
       $('#btnSave').textContent = L.btnSave;
       $('#btnLoad').textContent = L.btnLoad;
-      byId('btnChooseFile')?.textContent = T.chooseFile;
-      byId('btnUseCamera')?.textContent = T.useCamera;
+      var elCF = document.getElementById('btnChooseFile'); if (elCF) elCF.textContent = T.chooseFile;
+      var elUC = document.getElementById('btnUseCamera'); if (elUC) elUC.textContent = T.useCamera;
       $('#label-ask').textContent = L.askLabel;
       $('#question').placeholder = L.phQuestion;
       $('#btnAskSel').textContent = L.btnAskSel;

--- a/es/index.html
+++ b/es/index.html
@@ -318,8 +318,8 @@ body.sidebar-collapsed .show-sidebar-btn{ display:inline-block; }
       $('#btnExplainSel').textContent = L.btnExplainSel;
       $('#btnSave').textContent = L.btnSave;
       $('#btnLoad').textContent = L.btnLoad;
-      byId('btnChooseFile')?.textContent = T.chooseFile;
-      byId('btnUseCamera')?.textContent = T.useCamera;
+      var elCF = document.getElementById('btnChooseFile'); if (elCF) elCF.textContent = T.chooseFile;
+      var elUC = document.getElementById('btnUseCamera'); if (elUC) elUC.textContent = T.useCamera;
       $('#label-ask').textContent = L.askLabel;
       $('#question').placeholder = L.phQuestion;
       $('#btnAskSel').textContent = L.btnAskSel;

--- a/fr/index.html
+++ b/fr/index.html
@@ -318,8 +318,8 @@ body.sidebar-collapsed .show-sidebar-btn{ display:inline-block; }
       $('#btnExplainSel').textContent = L.btnExplainSel;
       $('#btnSave').textContent = L.btnSave;
       $('#btnLoad').textContent = L.btnLoad;
-      byId('btnChooseFile')?.textContent = T.chooseFile;
-      byId('btnUseCamera')?.textContent = T.useCamera;
+      var elCF = document.getElementById('btnChooseFile'); if (elCF) elCF.textContent = T.chooseFile;
+      var elUC = document.getElementById('btnUseCamera'); if (elUC) elUC.textContent = T.useCamera;
       $('#label-ask').textContent = L.askLabel;
       $('#question').placeholder = L.phQuestion;
       $('#btnAskSel').textContent = L.btnAskSel;

--- a/hi/index.html
+++ b/hi/index.html
@@ -318,8 +318,8 @@ body.sidebar-collapsed .show-sidebar-btn{ display:inline-block; }
       $('#btnExplainSel').textContent = L.btnExplainSel;
       $('#btnSave').textContent = L.btnSave;
       $('#btnLoad').textContent = L.btnLoad;
-      byId('btnChooseFile')?.textContent = T.chooseFile;
-      byId('btnUseCamera')?.textContent = T.useCamera;
+      var elCF = document.getElementById('btnChooseFile'); if (elCF) elCF.textContent = T.chooseFile;
+      var elUC = document.getElementById('btnUseCamera'); if (elUC) elUC.textContent = T.useCamera;
       $('#label-ask').textContent = L.askLabel;
       $('#question').placeholder = L.phQuestion;
       $('#btnAskSel').textContent = L.btnAskSel;

--- a/index.html
+++ b/index.html
@@ -318,8 +318,8 @@ body.sidebar-collapsed .show-sidebar-btn{ display:inline-block; }
       $('#btnExplainSel').textContent = L.btnExplainSel;
       $('#btnSave').textContent = L.btnSave;
       $('#btnLoad').textContent = L.btnLoad;
-      byId('btnChooseFile')?.textContent = T.chooseFile;
-      byId('btnUseCamera')?.textContent = T.useCamera;
+      var elCF = document.getElementById('btnChooseFile'); if (elCF) elCF.textContent = T.chooseFile;
+      var elUC = document.getElementById('btnUseCamera'); if (elUC) elUC.textContent = T.useCamera;
       $('#label-ask').textContent = L.askLabel;
       $('#question').placeholder = L.phQuestion;
       $('#btnAskSel').textContent = L.btnAskSel;

--- a/it/index.html
+++ b/it/index.html
@@ -318,8 +318,8 @@ body.sidebar-collapsed .show-sidebar-btn{ display:inline-block; }
       $('#btnExplainSel').textContent = L.btnExplainSel;
       $('#btnSave').textContent = L.btnSave;
       $('#btnLoad').textContent = L.btnLoad;
-      byId('btnChooseFile')?.textContent = T.chooseFile;
-      byId('btnUseCamera')?.textContent = T.useCamera;
+      var elCF = document.getElementById('btnChooseFile'); if (elCF) elCF.textContent = T.chooseFile;
+      var elUC = document.getElementById('btnUseCamera'); if (elUC) elUC.textContent = T.useCamera;
       $('#label-ask').textContent = L.askLabel;
       $('#question').placeholder = L.phQuestion;
       $('#btnAskSel').textContent = L.btnAskSel;

--- a/pt/index.html
+++ b/pt/index.html
@@ -318,8 +318,8 @@ body.sidebar-collapsed .show-sidebar-btn{ display:inline-block; }
       $('#btnExplainSel').textContent = L.btnExplainSel;
       $('#btnSave').textContent = L.btnSave;
       $('#btnLoad').textContent = L.btnLoad;
-      byId('btnChooseFile')?.textContent = T.chooseFile;
-      byId('btnUseCamera')?.textContent = T.useCamera;
+      var elCF = document.getElementById('btnChooseFile'); if (elCF) elCF.textContent = T.chooseFile;
+      var elUC = document.getElementById('btnUseCamera'); if (elUC) elUC.textContent = T.useCamera;
       $('#label-ask').textContent = L.askLabel;
       $('#question').placeholder = L.phQuestion;
       $('#btnAskSel').textContent = L.btnAskSel;

--- a/ru/index.html
+++ b/ru/index.html
@@ -318,8 +318,8 @@ body.sidebar-collapsed .show-sidebar-btn{ display:inline-block; }
       $('#btnExplainSel').textContent = L.btnExplainSel;
       $('#btnSave').textContent = L.btnSave;
       $('#btnLoad').textContent = L.btnLoad;
-      byId('btnChooseFile')?.textContent = T.chooseFile;
-      byId('btnUseCamera')?.textContent = T.useCamera;
+      var elCF = document.getElementById('btnChooseFile'); if (elCF) elCF.textContent = T.chooseFile;
+      var elUC = document.getElementById('btnUseCamera'); if (elUC) elUC.textContent = T.useCamera;
       $('#label-ask').textContent = L.askLabel;
       $('#question').placeholder = L.phQuestion;
       $('#btnAskSel').textContent = L.btnAskSel;

--- a/site.webmanifest
+++ b/site.webmanifest
@@ -1,11 +1,12 @@
 {
   "name": "DocuMate",
   "short_name": "DocuMate",
-  "icons": [
-    { "src": "/icon-192.png", "sizes": "192x192", "type": "image/png" }
-  ],
-  "theme_color": "#2563eb",
-  "background_color": "#ffffff",
+  "start_url": "/",
   "display": "standalone",
-  "start_url": "/"
+  "background_color": "#ffffff",
+  "theme_color": "#2563eb",
+  "icons": [
+    { "src": "/icon-192.png", "sizes": "192x192", "type": "image/png" },
+    { "src": "/icon-512.png", "sizes": "512x512", "type": "image/png" }
+  ]
 }

--- a/zh/index.html
+++ b/zh/index.html
@@ -318,8 +318,8 @@ body.sidebar-collapsed .show-sidebar-btn{ display:inline-block; }
       $('#btnExplainSel').textContent = L.btnExplainSel;
       $('#btnSave').textContent = L.btnSave;
       $('#btnLoad').textContent = L.btnLoad;
-      byId('btnChooseFile')?.textContent = T.chooseFile;
-      byId('btnUseCamera')?.textContent = T.useCamera;
+      var elCF = document.getElementById('btnChooseFile'); if (elCF) elCF.textContent = T.chooseFile;
+      var elUC = document.getElementById('btnUseCamera'); if (elUC) elUC.textContent = T.useCamera;
       $('#label-ask').textContent = L.askLabel;
       $('#question').placeholder = L.phQuestion;
       $('#btnAskSel').textContent = L.btnAskSel;


### PR DESCRIPTION
## Summary
- eliminate optional chaining assignments in all index pages to prevent "Invalid left-hand side" runtime errors
- refresh `site.webmanifest` with normalized schema and 192/512 icons

## Testing
- `npm test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 - cannot install npm)*

------
https://chatgpt.com/codex/tasks/task_e_68bb4ff244f08329a3a9f86186ebf593