### PR TITLE
feat(privacy): minimize panel to floating corner button

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -137,6 +137,27 @@
 body.sidebar-collapsed main{ grid-template-columns:1fr !important; }
 body.sidebar-collapsed #sidebar{ display:none; }
 body.sidebar-collapsed .show-sidebar-btn{ display:inline-block; }
+/* privacy floating action button */
+.privacy-fab{
+  position: fixed;
+  right: 16px;   /* change en 16px left: si tu préfères en bas-gauche */
+  bottom: 16px;
+  z-index: 60;
+  background: #111827;
+  color: #fff;
+  border: 0;
+  padding: 10px 14px;
+  border-radius: 999px;
+  box-shadow: 0 10px 30px rgba(2,6,23,.18);
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 14px;
+}
+.privacy-fab:focus{ outline: 2px solid #2563eb; outline-offset: 2px; }
+
+/* sécurité si l’ancien panneau utilise .privacy-panel.collapsed */
+.privacy-collapsed { display: none !important; }
+
 </style>
 </head>
 <body>
@@ -762,5 +783,6 @@ async function ensureHeavyLibs(){
 })();
 </script>
 <script defer src="/scripts/lang-switch.js"></script>
+<script defer src="/scripts/privacy-fab.js"></script>
 </body>
 </html>

--- a/bn/index.html
+++ b/bn/index.html
@@ -137,6 +137,27 @@
 body.sidebar-collapsed main{ grid-template-columns:1fr !important; }
 body.sidebar-collapsed #sidebar{ display:none; }
 body.sidebar-collapsed .show-sidebar-btn{ display:inline-block; }
+/* privacy floating action button */
+.privacy-fab{
+  position: fixed;
+  right: 16px;   /* change en 16px left: si tu préfères en bas-gauche */
+  bottom: 16px;
+  z-index: 60;
+  background: #111827;
+  color: #fff;
+  border: 0;
+  padding: 10px 14px;
+  border-radius: 999px;
+  box-shadow: 0 10px 30px rgba(2,6,23,.18);
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 14px;
+}
+.privacy-fab:focus{ outline: 2px solid #2563eb; outline-offset: 2px; }
+
+/* sécurité si l’ancien panneau utilise .privacy-panel.collapsed */
+.privacy-collapsed { display: none !important; }
+
 </style>
 </head>
 <body>
@@ -762,5 +783,6 @@ async function ensureHeavyLibs(){
 })();
 </script>
 <script defer src="/scripts/lang-switch.js"></script>
+<script defer src="/scripts/privacy-fab.js"></script>
 </body>
 </html>

--- a/de/index.html
+++ b/de/index.html
@@ -137,6 +137,27 @@
 body.sidebar-collapsed main{ grid-template-columns:1fr !important; }
 body.sidebar-collapsed #sidebar{ display:none; }
 body.sidebar-collapsed .show-sidebar-btn{ display:inline-block; }
+/* privacy floating action button */
+.privacy-fab{
+  position: fixed;
+  right: 16px;   /* change en 16px left: si tu préfères en bas-gauche */
+  bottom: 16px;
+  z-index: 60;
+  background: #111827;
+  color: #fff;
+  border: 0;
+  padding: 10px 14px;
+  border-radius: 999px;
+  box-shadow: 0 10px 30px rgba(2,6,23,.18);
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 14px;
+}
+.privacy-fab:focus{ outline: 2px solid #2563eb; outline-offset: 2px; }
+
+/* sécurité si l’ancien panneau utilise .privacy-panel.collapsed */
+.privacy-collapsed { display: none !important; }
+
 </style>
 </head>
 <body>
@@ -762,5 +783,6 @@ async function ensureHeavyLibs(){
 })();
 </script>
 <script defer src="/scripts/lang-switch.js"></script>
+<script defer src="/scripts/privacy-fab.js"></script>
 </body>
 </html>

--- a/en/index.html
+++ b/en/index.html
@@ -137,6 +137,27 @@
 body.sidebar-collapsed main{ grid-template-columns:1fr !important; }
 body.sidebar-collapsed #sidebar{ display:none; }
 body.sidebar-collapsed .show-sidebar-btn{ display:inline-block; }
+/* privacy floating action button */
+.privacy-fab{
+  position: fixed;
+  right: 16px;   /* change en 16px left: si tu préfères en bas-gauche */
+  bottom: 16px;
+  z-index: 60;
+  background: #111827;
+  color: #fff;
+  border: 0;
+  padding: 10px 14px;
+  border-radius: 999px;
+  box-shadow: 0 10px 30px rgba(2,6,23,.18);
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 14px;
+}
+.privacy-fab:focus{ outline: 2px solid #2563eb; outline-offset: 2px; }
+
+/* sécurité si l’ancien panneau utilise .privacy-panel.collapsed */
+.privacy-collapsed { display: none !important; }
+
 </style>
 </head>
 <body>
@@ -762,5 +783,6 @@ async function ensureHeavyLibs(){
 })();
 </script>
 <script defer src="/scripts/lang-switch.js"></script>
+<script defer src="/scripts/privacy-fab.js"></script>
 </body>
 </html>

--- a/es/index.html
+++ b/es/index.html
@@ -137,6 +137,27 @@
 body.sidebar-collapsed main{ grid-template-columns:1fr !important; }
 body.sidebar-collapsed #sidebar{ display:none; }
 body.sidebar-collapsed .show-sidebar-btn{ display:inline-block; }
+/* privacy floating action button */
+.privacy-fab{
+  position: fixed;
+  right: 16px;   /* change en 16px left: si tu préfères en bas-gauche */
+  bottom: 16px;
+  z-index: 60;
+  background: #111827;
+  color: #fff;
+  border: 0;
+  padding: 10px 14px;
+  border-radius: 999px;
+  box-shadow: 0 10px 30px rgba(2,6,23,.18);
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 14px;
+}
+.privacy-fab:focus{ outline: 2px solid #2563eb; outline-offset: 2px; }
+
+/* sécurité si l’ancien panneau utilise .privacy-panel.collapsed */
+.privacy-collapsed { display: none !important; }
+
 </style>
 </head>
 <body>
@@ -762,5 +783,6 @@ async function ensureHeavyLibs(){
 })();
 </script>
 <script defer src="/scripts/lang-switch.js"></script>
+<script defer src="/scripts/privacy-fab.js"></script>
 </body>
 </html>

--- a/fr/index.html
+++ b/fr/index.html
@@ -137,6 +137,27 @@
 body.sidebar-collapsed main{ grid-template-columns:1fr !important; }
 body.sidebar-collapsed #sidebar{ display:none; }
 body.sidebar-collapsed .show-sidebar-btn{ display:inline-block; }
+/* privacy floating action button */
+.privacy-fab{
+  position: fixed;
+  right: 16px;   /* change en 16px left: si tu préfères en bas-gauche */
+  bottom: 16px;
+  z-index: 60;
+  background: #111827;
+  color: #fff;
+  border: 0;
+  padding: 10px 14px;
+  border-radius: 999px;
+  box-shadow: 0 10px 30px rgba(2,6,23,.18);
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 14px;
+}
+.privacy-fab:focus{ outline: 2px solid #2563eb; outline-offset: 2px; }
+
+/* sécurité si l’ancien panneau utilise .privacy-panel.collapsed */
+.privacy-collapsed { display: none !important; }
+
 </style>
 </head>
 <body>
@@ -762,5 +783,6 @@ async function ensureHeavyLibs(){
 })();
 </script>
 <script defer src="/scripts/lang-switch.js"></script>
+<script defer src="/scripts/privacy-fab.js"></script>
 </body>
 </html>

--- a/hi/index.html
+++ b/hi/index.html
@@ -137,6 +137,27 @@
 body.sidebar-collapsed main{ grid-template-columns:1fr !important; }
 body.sidebar-collapsed #sidebar{ display:none; }
 body.sidebar-collapsed .show-sidebar-btn{ display:inline-block; }
+/* privacy floating action button */
+.privacy-fab{
+  position: fixed;
+  right: 16px;   /* change en 16px left: si tu préfères en bas-gauche */
+  bottom: 16px;
+  z-index: 60;
+  background: #111827;
+  color: #fff;
+  border: 0;
+  padding: 10px 14px;
+  border-radius: 999px;
+  box-shadow: 0 10px 30px rgba(2,6,23,.18);
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 14px;
+}
+.privacy-fab:focus{ outline: 2px solid #2563eb; outline-offset: 2px; }
+
+/* sécurité si l’ancien panneau utilise .privacy-panel.collapsed */
+.privacy-collapsed { display: none !important; }
+
 </style>
 </head>
 <body>
@@ -762,5 +783,6 @@ async function ensureHeavyLibs(){
 })();
 </script>
 <script defer src="/scripts/lang-switch.js"></script>
+<script defer src="/scripts/privacy-fab.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -137,6 +137,27 @@
 body.sidebar-collapsed main{ grid-template-columns:1fr !important; }
 body.sidebar-collapsed #sidebar{ display:none; }
 body.sidebar-collapsed .show-sidebar-btn{ display:inline-block; }
+/* privacy floating action button */
+.privacy-fab{
+  position: fixed;
+  right: 16px;   /* change en 16px left: si tu préfères en bas-gauche */
+  bottom: 16px;
+  z-index: 60;
+  background: #111827;
+  color: #fff;
+  border: 0;
+  padding: 10px 14px;
+  border-radius: 999px;
+  box-shadow: 0 10px 30px rgba(2,6,23,.18);
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 14px;
+}
+.privacy-fab:focus{ outline: 2px solid #2563eb; outline-offset: 2px; }
+
+/* sécurité si l’ancien panneau utilise .privacy-panel.collapsed */
+.privacy-collapsed { display: none !important; }
+
 </style>
 </head>
 <body>
@@ -762,5 +783,6 @@ async function ensureHeavyLibs(){
 })();
 </script>
 <script defer src="/scripts/lang-switch.js"></script>
+<script defer src="/scripts/privacy-fab.js"></script>
 </body>
 </html>

--- a/it/index.html
+++ b/it/index.html
@@ -137,6 +137,27 @@
 body.sidebar-collapsed main{ grid-template-columns:1fr !important; }
 body.sidebar-collapsed #sidebar{ display:none; }
 body.sidebar-collapsed .show-sidebar-btn{ display:inline-block; }
+/* privacy floating action button */
+.privacy-fab{
+  position: fixed;
+  right: 16px;   /* change en 16px left: si tu préfères en bas-gauche */
+  bottom: 16px;
+  z-index: 60;
+  background: #111827;
+  color: #fff;
+  border: 0;
+  padding: 10px 14px;
+  border-radius: 999px;
+  box-shadow: 0 10px 30px rgba(2,6,23,.18);
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 14px;
+}
+.privacy-fab:focus{ outline: 2px solid #2563eb; outline-offset: 2px; }
+
+/* sécurité si l’ancien panneau utilise .privacy-panel.collapsed */
+.privacy-collapsed { display: none !important; }
+
 </style>
 </head>
 <body>
@@ -762,5 +783,6 @@ async function ensureHeavyLibs(){
 })();
 </script>
 <script defer src="/scripts/lang-switch.js"></script>
+<script defer src="/scripts/privacy-fab.js"></script>
 </body>
 </html>

--- a/pt/index.html
+++ b/pt/index.html
@@ -137,6 +137,27 @@
 body.sidebar-collapsed main{ grid-template-columns:1fr !important; }
 body.sidebar-collapsed #sidebar{ display:none; }
 body.sidebar-collapsed .show-sidebar-btn{ display:inline-block; }
+/* privacy floating action button */
+.privacy-fab{
+  position: fixed;
+  right: 16px;   /* change en 16px left: si tu préfères en bas-gauche */
+  bottom: 16px;
+  z-index: 60;
+  background: #111827;
+  color: #fff;
+  border: 0;
+  padding: 10px 14px;
+  border-radius: 999px;
+  box-shadow: 0 10px 30px rgba(2,6,23,.18);
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 14px;
+}
+.privacy-fab:focus{ outline: 2px solid #2563eb; outline-offset: 2px; }
+
+/* sécurité si l’ancien panneau utilise .privacy-panel.collapsed */
+.privacy-collapsed { display: none !important; }
+
 </style>
 </head>
 <body>
@@ -762,5 +783,6 @@ async function ensureHeavyLibs(){
 })();
 </script>
 <script defer src="/scripts/lang-switch.js"></script>
+<script defer src="/scripts/privacy-fab.js"></script>
 </body>
 </html>

--- a/ru/index.html
+++ b/ru/index.html
@@ -137,6 +137,27 @@
 body.sidebar-collapsed main{ grid-template-columns:1fr !important; }
 body.sidebar-collapsed #sidebar{ display:none; }
 body.sidebar-collapsed .show-sidebar-btn{ display:inline-block; }
+/* privacy floating action button */
+.privacy-fab{
+  position: fixed;
+  right: 16px;   /* change en 16px left: si tu préfères en bas-gauche */
+  bottom: 16px;
+  z-index: 60;
+  background: #111827;
+  color: #fff;
+  border: 0;
+  padding: 10px 14px;
+  border-radius: 999px;
+  box-shadow: 0 10px 30px rgba(2,6,23,.18);
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 14px;
+}
+.privacy-fab:focus{ outline: 2px solid #2563eb; outline-offset: 2px; }
+
+/* sécurité si l’ancien panneau utilise .privacy-panel.collapsed */
+.privacy-collapsed { display: none !important; }
+
 </style>
 </head>
 <body>
@@ -762,5 +783,6 @@ async function ensureHeavyLibs(){
 })();
 </script>
 <script defer src="/scripts/lang-switch.js"></script>
+<script defer src="/scripts/privacy-fab.js"></script>
 </body>
 </html>

--- a/scripts/privacy-fab.js
+++ b/scripts/privacy-fab.js
@@ -1,0 +1,103 @@
+/* SPDX-FileCopyrightText: 2025 DocExpain
+ * SPDX-License-Identifier: LicenseRef-SA-NC-1.0
+ */
+(function () {
+  function t(key, fallback) {
+    try {
+      var lang = (document.documentElement.lang || 'en').toLowerCase();
+      var T = (window.I18N && window.I18N[lang]) || {};
+      return (T && T[key]) || fallback;
+    } catch (e) { return fallback; }
+  }
+
+  function applyState(open) {
+    // hide/show panel and fab
+    if (panel) {
+      // si on est sur <details>, on laisse open=true pendant l’affichage puis on cache totalement quand fermé
+      if (isDetails) {
+        if (open) {
+          panel.open = true;
+          panel.style.display = '';
+        } else {
+          panel.open = false;
+          // on cache entièrement le bloc pour libérer l’espace (et masquer le <summary>)
+          panel.style.display = 'none';
+        }
+      } else {
+        panel.classList.toggle('privacy-collapsed', !open);
+        panel.style.display = open ? '' : 'none';
+      }
+    }
+    if (fab) {
+      fab.hidden = !!open;
+      fab.setAttribute('aria-expanded', open ? 'true' : 'false');
+      fab.setAttribute('title', open ? hideLbl : showLbl);
+    }
+    try { localStorage.setItem('privacy-open', open ? '1' : '0'); } catch (e) {}
+  }
+
+  function restore() {
+    var saved = null;
+    try { saved = localStorage.getItem('privacy-open'); } catch (e) {}
+    return saved !== '0'; // défaut: ouvert
+  }
+
+  // 1) Détection du panneau : supporte <details id="privacyBox"> ou <div id="privacy-panel"> / .card.legal
+  var panel = document.getElementById('privacyBox')
+          || document.getElementById('privacy-panel')
+          || document.querySelector('.card.legal,#privacyBox');
+  if (!panel) return;
+
+  var isDetails = panel.tagName === 'DETAILS';
+
+  // 2) Créer la puce flottante
+  var showLbl = t('showPrivacy', 'Afficher');
+  var hideLbl = t('hidePrivacy', 'Masquer');
+
+  var fab = document.getElementById('privacy-fab');
+  if (!fab) {
+    fab = document.createElement('button');
+    fab.id = 'privacy-fab';
+    fab.type = 'button';
+    fab.className = 'privacy-fab';
+    fab.setAttribute('aria-controls', panel.id || 'privacyBox');
+    fab.setAttribute('aria-expanded', 'false');
+    fab.hidden = true;
+    fab.textContent = showLbl;
+    document.body.appendChild(fab);
+  }
+
+  // 3) Raccorder tes contrôles existants (si présents)
+  var btnLegacy = document.getElementById('privacy-toggle');     // ancienne implémentation
+  var sum = isDetails ? panel.querySelector('summary') : null;   // <summary> si <details>
+
+  function minimize(e) {
+    if (e) e.preventDefault();
+    applyState(false);
+  }
+  function reopen(e) {
+    if (e) e.preventDefault();
+    applyState(true);
+    try { panel.scrollIntoView({ behavior: 'smooth', block: 'start' }); } catch (e2) {}
+  }
+
+  // 4) Écouteurs : clic sur la puce pour ré-ouvrir
+  fab.addEventListener('click', reopen);
+
+  // 5) Si on a un bouton existant “Masquer”, on le branche sur minimize
+  if (btnLegacy) btnLegacy.addEventListener('click', function (e) {
+    e.preventDefault(); minimize();
+  });
+
+  // 6) Si <details>, on intercepte le toggle
+  if (isDetails && sum) {
+    panel.addEventListener('toggle', function () {
+      // Si l’utilisateur “ferme” le details, on passe en mode fab (panel hidden)
+      if (!panel.open) { applyState(false); }
+      else { applyState(true); }
+    });
+  }
+
+  // 7) État initial depuis localStorage
+  applyState(restore());
+})();

--- a/zh/index.html
+++ b/zh/index.html
@@ -137,6 +137,27 @@
 body.sidebar-collapsed main{ grid-template-columns:1fr !important; }
 body.sidebar-collapsed #sidebar{ display:none; }
 body.sidebar-collapsed .show-sidebar-btn{ display:inline-block; }
+/* privacy floating action button */
+.privacy-fab{
+  position: fixed;
+  right: 16px;   /* change en 16px left: si tu préfères en bas-gauche */
+  bottom: 16px;
+  z-index: 60;
+  background: #111827;
+  color: #fff;
+  border: 0;
+  padding: 10px 14px;
+  border-radius: 999px;
+  box-shadow: 0 10px 30px rgba(2,6,23,.18);
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 14px;
+}
+.privacy-fab:focus{ outline: 2px solid #2563eb; outline-offset: 2px; }
+
+/* sécurité si l’ancien panneau utilise .privacy-panel.collapsed */
+.privacy-collapsed { display: none !important; }
+
 </style>
 </head>
 <body>
@@ -762,5 +783,6 @@ async function ensureHeavyLibs(){
 })();
 </script>
 <script defer src="/scripts/lang-switch.js"></script>
+<script defer src="/scripts/privacy-fab.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add privacy panel script for floating action button and state persistence
- wire up script and styles across all localized index pages

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68be893bd83c8329bcd4a258f2887b20