### PR TITLE
style(layout): expand left column to full width when privacy panel is hidden (desktop & mobile); ids work-card/privacy-card

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -177,6 +177,22 @@ main.no-privacy { grid-template-columns: 1fr !important; }
   font-size: 14px;
 }
 .privacy-fab:focus { outline: 2px solid #2563eb; outline-offset: 2px; }
+/* When privacy is hidden, make the grid single-column and expand the left card */
+main.no-privacy{
+  grid-template-columns: minmax(0,1fr) !important; /* full width, no second column */
+}
+main.no-privacy > #work-card{
+  grid-column: 1 / -1;      /* span all columns */
+  width: 100%;
+}
+main.no-privacy > #privacy-card{
+  display: none !important; /* ensure no ghost column */
+}
+
+/* Mobile already uses 1 column, keep it explicit */
+@media (max-width: 980px){
+  main{ grid-template-columns: 1fr; }
+}
 </style>
 </head>
 <body>
@@ -202,7 +218,7 @@ main.no-privacy { grid-template-columns: 1fr !important; }
   </header>
 
   <main>
-    <section class="card">
+    <section class="card" id="work-card">
       <div class="hero">
         <h2 id="hero-title">Explain contracts, bills & official documents in plain language</h2>
         <p id="hero-sub">Free, private, multilingual. Not legal advice.</p>

--- a/bn/index.html
+++ b/bn/index.html
@@ -177,6 +177,22 @@ main.no-privacy { grid-template-columns: 1fr !important; }
   font-size: 14px;
 }
 .privacy-fab:focus { outline: 2px solid #2563eb; outline-offset: 2px; }
+/* When privacy is hidden, make the grid single-column and expand the left card */
+main.no-privacy{
+  grid-template-columns: minmax(0,1fr) !important; /* full width, no second column */
+}
+main.no-privacy > #work-card{
+  grid-column: 1 / -1;      /* span all columns */
+  width: 100%;
+}
+main.no-privacy > #privacy-card{
+  display: none !important; /* ensure no ghost column */
+}
+
+/* Mobile already uses 1 column, keep it explicit */
+@media (max-width: 980px){
+  main{ grid-template-columns: 1fr; }
+}
 </style>
 </head>
 <body>
@@ -202,7 +218,7 @@ main.no-privacy { grid-template-columns: 1fr !important; }
   </header>
 
   <main>
-    <section class="card">
+    <section class="card" id="work-card">
       <div class="hero">
         <h2 id="hero-title">Explain contracts, bills & official documents in plain language</h2>
         <p id="hero-sub">Free, private, multilingual. Not legal advice.</p>

--- a/de/index.html
+++ b/de/index.html
@@ -177,6 +177,22 @@ main.no-privacy { grid-template-columns: 1fr !important; }
   font-size: 14px;
 }
 .privacy-fab:focus { outline: 2px solid #2563eb; outline-offset: 2px; }
+/* When privacy is hidden, make the grid single-column and expand the left card */
+main.no-privacy{
+  grid-template-columns: minmax(0,1fr) !important; /* full width, no second column */
+}
+main.no-privacy > #work-card{
+  grid-column: 1 / -1;      /* span all columns */
+  width: 100%;
+}
+main.no-privacy > #privacy-card{
+  display: none !important; /* ensure no ghost column */
+}
+
+/* Mobile already uses 1 column, keep it explicit */
+@media (max-width: 980px){
+  main{ grid-template-columns: 1fr; }
+}
 </style>
 </head>
 <body>
@@ -202,7 +218,7 @@ main.no-privacy { grid-template-columns: 1fr !important; }
   </header>
 
   <main>
-    <section class="card">
+    <section class="card" id="work-card">
       <div class="hero">
         <h2 id="hero-title">Explain contracts, bills & official documents in plain language</h2>
         <p id="hero-sub">Free, private, multilingual. Not legal advice.</p>

--- a/en/index.html
+++ b/en/index.html
@@ -177,6 +177,22 @@ main.no-privacy { grid-template-columns: 1fr !important; }
   font-size: 14px;
 }
 .privacy-fab:focus { outline: 2px solid #2563eb; outline-offset: 2px; }
+/* When privacy is hidden, make the grid single-column and expand the left card */
+main.no-privacy{
+  grid-template-columns: minmax(0,1fr) !important; /* full width, no second column */
+}
+main.no-privacy > #work-card{
+  grid-column: 1 / -1;      /* span all columns */
+  width: 100%;
+}
+main.no-privacy > #privacy-card{
+  display: none !important; /* ensure no ghost column */
+}
+
+/* Mobile already uses 1 column, keep it explicit */
+@media (max-width: 980px){
+  main{ grid-template-columns: 1fr; }
+}
 </style>
 </head>
 <body>
@@ -202,7 +218,7 @@ main.no-privacy { grid-template-columns: 1fr !important; }
   </header>
 
   <main>
-    <section class="card">
+    <section class="card" id="work-card">
       <div class="hero">
         <h2 id="hero-title">Explain contracts, bills & official documents in plain language</h2>
         <p id="hero-sub">Free, private, multilingual. Not legal advice.</p>

--- a/es/index.html
+++ b/es/index.html
@@ -177,6 +177,22 @@ main.no-privacy { grid-template-columns: 1fr !important; }
   font-size: 14px;
 }
 .privacy-fab:focus { outline: 2px solid #2563eb; outline-offset: 2px; }
+/* When privacy is hidden, make the grid single-column and expand the left card */
+main.no-privacy{
+  grid-template-columns: minmax(0,1fr) !important; /* full width, no second column */
+}
+main.no-privacy > #work-card{
+  grid-column: 1 / -1;      /* span all columns */
+  width: 100%;
+}
+main.no-privacy > #privacy-card{
+  display: none !important; /* ensure no ghost column */
+}
+
+/* Mobile already uses 1 column, keep it explicit */
+@media (max-width: 980px){
+  main{ grid-template-columns: 1fr; }
+}
 </style>
 </head>
 <body>
@@ -202,7 +218,7 @@ main.no-privacy { grid-template-columns: 1fr !important; }
   </header>
 
   <main>
-    <section class="card">
+    <section class="card" id="work-card">
       <div class="hero">
         <h2 id="hero-title">Explain contracts, bills & official documents in plain language</h2>
         <p id="hero-sub">Free, private, multilingual. Not legal advice.</p>

--- a/fr/index.html
+++ b/fr/index.html
@@ -177,6 +177,22 @@ main.no-privacy { grid-template-columns: 1fr !important; }
   font-size: 14px;
 }
 .privacy-fab:focus { outline: 2px solid #2563eb; outline-offset: 2px; }
+/* When privacy is hidden, make the grid single-column and expand the left card */
+main.no-privacy{
+  grid-template-columns: minmax(0,1fr) !important; /* full width, no second column */
+}
+main.no-privacy > #work-card{
+  grid-column: 1 / -1;      /* span all columns */
+  width: 100%;
+}
+main.no-privacy > #privacy-card{
+  display: none !important; /* ensure no ghost column */
+}
+
+/* Mobile already uses 1 column, keep it explicit */
+@media (max-width: 980px){
+  main{ grid-template-columns: 1fr; }
+}
 </style>
 </head>
 <body>
@@ -202,7 +218,7 @@ main.no-privacy { grid-template-columns: 1fr !important; }
   </header>
 
   <main>
-    <section class="card">
+    <section class="card" id="work-card">
       <div class="hero">
         <h2 id="hero-title">Explain contracts, bills & official documents in plain language</h2>
         <p id="hero-sub">Free, private, multilingual. Not legal advice.</p>

--- a/hi/index.html
+++ b/hi/index.html
@@ -177,6 +177,22 @@ main.no-privacy { grid-template-columns: 1fr !important; }
   font-size: 14px;
 }
 .privacy-fab:focus { outline: 2px solid #2563eb; outline-offset: 2px; }
+/* When privacy is hidden, make the grid single-column and expand the left card */
+main.no-privacy{
+  grid-template-columns: minmax(0,1fr) !important; /* full width, no second column */
+}
+main.no-privacy > #work-card{
+  grid-column: 1 / -1;      /* span all columns */
+  width: 100%;
+}
+main.no-privacy > #privacy-card{
+  display: none !important; /* ensure no ghost column */
+}
+
+/* Mobile already uses 1 column, keep it explicit */
+@media (max-width: 980px){
+  main{ grid-template-columns: 1fr; }
+}
 </style>
 </head>
 <body>
@@ -202,7 +218,7 @@ main.no-privacy { grid-template-columns: 1fr !important; }
   </header>
 
   <main>
-    <section class="card">
+    <section class="card" id="work-card">
       <div class="hero">
         <h2 id="hero-title">Explain contracts, bills & official documents in plain language</h2>
         <p id="hero-sub">Free, private, multilingual. Not legal advice.</p>

--- a/index.html
+++ b/index.html
@@ -177,6 +177,22 @@ main.no-privacy { grid-template-columns: 1fr !important; }
   font-size: 14px;
 }
 .privacy-fab:focus { outline: 2px solid #2563eb; outline-offset: 2px; }
+/* When privacy is hidden, make the grid single-column and expand the left card */
+main.no-privacy{
+  grid-template-columns: minmax(0,1fr) !important; /* full width, no second column */
+}
+main.no-privacy > #work-card{
+  grid-column: 1 / -1;      /* span all columns */
+  width: 100%;
+}
+main.no-privacy > #privacy-card{
+  display: none !important; /* ensure no ghost column */
+}
+
+/* Mobile already uses 1 column, keep it explicit */
+@media (max-width: 980px){
+  main{ grid-template-columns: 1fr; }
+}
 </style>
 </head>
 <body>
@@ -202,7 +218,7 @@ main.no-privacy { grid-template-columns: 1fr !important; }
   </header>
 
   <main>
-    <section class="card">
+    <section class="card" id="work-card">
       <div class="hero">
         <h2 id="hero-title">Explain contracts, bills & official documents in plain language</h2>
         <p id="hero-sub">Free, private, multilingual. Not legal advice.</p>

--- a/it/index.html
+++ b/it/index.html
@@ -177,6 +177,22 @@ main.no-privacy { grid-template-columns: 1fr !important; }
   font-size: 14px;
 }
 .privacy-fab:focus { outline: 2px solid #2563eb; outline-offset: 2px; }
+/* When privacy is hidden, make the grid single-column and expand the left card */
+main.no-privacy{
+  grid-template-columns: minmax(0,1fr) !important; /* full width, no second column */
+}
+main.no-privacy > #work-card{
+  grid-column: 1 / -1;      /* span all columns */
+  width: 100%;
+}
+main.no-privacy > #privacy-card{
+  display: none !important; /* ensure no ghost column */
+}
+
+/* Mobile already uses 1 column, keep it explicit */
+@media (max-width: 980px){
+  main{ grid-template-columns: 1fr; }
+}
 </style>
 </head>
 <body>
@@ -202,7 +218,7 @@ main.no-privacy { grid-template-columns: 1fr !important; }
   </header>
 
   <main>
-    <section class="card">
+    <section class="card" id="work-card">
       <div class="hero">
         <h2 id="hero-title">Explain contracts, bills & official documents in plain language</h2>
         <p id="hero-sub">Free, private, multilingual. Not legal advice.</p>

--- a/pt/index.html
+++ b/pt/index.html
@@ -177,6 +177,22 @@ main.no-privacy { grid-template-columns: 1fr !important; }
   font-size: 14px;
 }
 .privacy-fab:focus { outline: 2px solid #2563eb; outline-offset: 2px; }
+/* When privacy is hidden, make the grid single-column and expand the left card */
+main.no-privacy{
+  grid-template-columns: minmax(0,1fr) !important; /* full width, no second column */
+}
+main.no-privacy > #work-card{
+  grid-column: 1 / -1;      /* span all columns */
+  width: 100%;
+}
+main.no-privacy > #privacy-card{
+  display: none !important; /* ensure no ghost column */
+}
+
+/* Mobile already uses 1 column, keep it explicit */
+@media (max-width: 980px){
+  main{ grid-template-columns: 1fr; }
+}
 </style>
 </head>
 <body>
@@ -202,7 +218,7 @@ main.no-privacy { grid-template-columns: 1fr !important; }
   </header>
 
   <main>
-    <section class="card">
+    <section class="card" id="work-card">
       <div class="hero">
         <h2 id="hero-title">Explain contracts, bills & official documents in plain language</h2>
         <p id="hero-sub">Free, private, multilingual. Not legal advice.</p>

--- a/ru/index.html
+++ b/ru/index.html
@@ -177,6 +177,22 @@ main.no-privacy { grid-template-columns: 1fr !important; }
   font-size: 14px;
 }
 .privacy-fab:focus { outline: 2px solid #2563eb; outline-offset: 2px; }
+/* When privacy is hidden, make the grid single-column and expand the left card */
+main.no-privacy{
+  grid-template-columns: minmax(0,1fr) !important; /* full width, no second column */
+}
+main.no-privacy > #work-card{
+  grid-column: 1 / -1;      /* span all columns */
+  width: 100%;
+}
+main.no-privacy > #privacy-card{
+  display: none !important; /* ensure no ghost column */
+}
+
+/* Mobile already uses 1 column, keep it explicit */
+@media (max-width: 980px){
+  main{ grid-template-columns: 1fr; }
+}
 </style>
 </head>
 <body>
@@ -202,7 +218,7 @@ main.no-privacy { grid-template-columns: 1fr !important; }
   </header>
 
   <main>
-    <section class="card">
+    <section class="card" id="work-card">
       <div class="hero">
         <h2 id="hero-title">Explain contracts, bills & official documents in plain language</h2>
         <p id="hero-sub">Free, private, multilingual. Not legal advice.</p>

--- a/zh/index.html
+++ b/zh/index.html
@@ -177,6 +177,22 @@ main.no-privacy { grid-template-columns: 1fr !important; }
   font-size: 14px;
 }
 .privacy-fab:focus { outline: 2px solid #2563eb; outline-offset: 2px; }
+/* When privacy is hidden, make the grid single-column and expand the left card */
+main.no-privacy{
+  grid-template-columns: minmax(0,1fr) !important; /* full width, no second column */
+}
+main.no-privacy > #work-card{
+  grid-column: 1 / -1;      /* span all columns */
+  width: 100%;
+}
+main.no-privacy > #privacy-card{
+  display: none !important; /* ensure no ghost column */
+}
+
+/* Mobile already uses 1 column, keep it explicit */
+@media (max-width: 980px){
+  main{ grid-template-columns: 1fr; }
+}
 </style>
 </head>
 <body>
@@ -202,7 +218,7 @@ main.no-privacy { grid-template-columns: 1fr !important; }
   </header>
 
   <main>
-    <section class="card">
+    <section class="card" id="work-card">
       <div class="hero">
         <h2 id="hero-title">Explain contracts, bills & official documents in plain language</h2>
         <p id="hero-sub">Free, private, multilingual. Not legal advice.</p>


### PR DESCRIPTION
## Summary
- assign id="work-card" to the main content card across all pages
- add CSS so the left card expands to full width when the privacy panel is hidden, and keep 1-column layout on mobile

## Testing
- `npm test` *(fails: Missing script: "test" )*

------
https://chatgpt.com/codex/tasks/task_e_68be905d051483299391209c74b8493c