### PR TITLE
style(layout): adjust layout when privacy hidden

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -193,6 +193,26 @@ main.no-privacy > #privacy-card{
 @media (max-width: 980px){
   main{ grid-template-columns: 1fr; }
 }
+
+
+/* Single-column + restore rules when privacy is hidden */
+main.no-privacy{
+  grid-template-columns: minmax(0,1fr) !important; /* one column */
+  grid-auto-flow: row dense;
+}
+main.no-privacy > #work-card{
+  grid-column: 1 / -1; /* span full width */
+  width: 100%;
+}
+main.no-privacy > #privacy-card{
+  display: none !important; /* hide privacy card entirely */
+}
+/* Make the “Documents we can help with” full-width and place it at top when privacy hidden */
+main.no-privacy > #help-card.fullwidth-help{
+  grid-column: 1 / -1;
+  width: 100%;
+  margin-bottom: 16px;
+}
 </style>
 </head>
 <body>
@@ -311,7 +331,7 @@ main.no-privacy > #privacy-card{
     </div>
   </details>
 
-  <div style="grid-column:2;">
+  <div style="grid-column:2;" id="help-card">
     <h3 style="margin-top:18px;" id="seo-title">Documents we can help with</h3>
     <p class="legal" id="seo-text">Contracts, rental agreements, utility bills, bank letters, insurance terms, general conditions, and more.</p>
   </div>

--- a/bn/index.html
+++ b/bn/index.html
@@ -193,6 +193,26 @@ main.no-privacy > #privacy-card{
 @media (max-width: 980px){
   main{ grid-template-columns: 1fr; }
 }
+
+
+/* Single-column + restore rules when privacy is hidden */
+main.no-privacy{
+  grid-template-columns: minmax(0,1fr) !important; /* one column */
+  grid-auto-flow: row dense;
+}
+main.no-privacy > #work-card{
+  grid-column: 1 / -1; /* span full width */
+  width: 100%;
+}
+main.no-privacy > #privacy-card{
+  display: none !important; /* hide privacy card entirely */
+}
+/* Make the “Documents we can help with” full-width and place it at top when privacy hidden */
+main.no-privacy > #help-card.fullwidth-help{
+  grid-column: 1 / -1;
+  width: 100%;
+  margin-bottom: 16px;
+}
 </style>
 </head>
 <body>
@@ -311,7 +331,7 @@ main.no-privacy > #privacy-card{
     </div>
   </details>
 
-  <div style="grid-column:2;">
+  <div style="grid-column:2;" id="help-card">
     <h3 style="margin-top:18px;" id="seo-title">Documents we can help with</h3>
     <p class="legal" id="seo-text">Contracts, rental agreements, utility bills, bank letters, insurance terms, general conditions, and more.</p>
   </div>

--- a/de/index.html
+++ b/de/index.html
@@ -193,6 +193,26 @@ main.no-privacy > #privacy-card{
 @media (max-width: 980px){
   main{ grid-template-columns: 1fr; }
 }
+
+
+/* Single-column + restore rules when privacy is hidden */
+main.no-privacy{
+  grid-template-columns: minmax(0,1fr) !important; /* one column */
+  grid-auto-flow: row dense;
+}
+main.no-privacy > #work-card{
+  grid-column: 1 / -1; /* span full width */
+  width: 100%;
+}
+main.no-privacy > #privacy-card{
+  display: none !important; /* hide privacy card entirely */
+}
+/* Make the “Documents we can help with” full-width and place it at top when privacy hidden */
+main.no-privacy > #help-card.fullwidth-help{
+  grid-column: 1 / -1;
+  width: 100%;
+  margin-bottom: 16px;
+}
 </style>
 </head>
 <body>
@@ -311,7 +331,7 @@ main.no-privacy > #privacy-card{
     </div>
   </details>
 
-  <div style="grid-column:2;">
+  <div style="grid-column:2;" id="help-card">
     <h3 style="margin-top:18px;" id="seo-title">Documents we can help with</h3>
     <p class="legal" id="seo-text">Contracts, rental agreements, utility bills, bank letters, insurance terms, general conditions, and more.</p>
   </div>

--- a/en/index.html
+++ b/en/index.html
@@ -193,6 +193,26 @@ main.no-privacy > #privacy-card{
 @media (max-width: 980px){
   main{ grid-template-columns: 1fr; }
 }
+
+
+/* Single-column + restore rules when privacy is hidden */
+main.no-privacy{
+  grid-template-columns: minmax(0,1fr) !important; /* one column */
+  grid-auto-flow: row dense;
+}
+main.no-privacy > #work-card{
+  grid-column: 1 / -1; /* span full width */
+  width: 100%;
+}
+main.no-privacy > #privacy-card{
+  display: none !important; /* hide privacy card entirely */
+}
+/* Make the “Documents we can help with” full-width and place it at top when privacy hidden */
+main.no-privacy > #help-card.fullwidth-help{
+  grid-column: 1 / -1;
+  width: 100%;
+  margin-bottom: 16px;
+}
 </style>
 </head>
 <body>
@@ -311,7 +331,7 @@ main.no-privacy > #privacy-card{
     </div>
   </details>
 
-  <div style="grid-column:2;">
+  <div style="grid-column:2;" id="help-card">
     <h3 style="margin-top:18px;" id="seo-title">Documents we can help with</h3>
     <p class="legal" id="seo-text">Contracts, rental agreements, utility bills, bank letters, insurance terms, general conditions, and more.</p>
   </div>

--- a/es/index.html
+++ b/es/index.html
@@ -193,6 +193,26 @@ main.no-privacy > #privacy-card{
 @media (max-width: 980px){
   main{ grid-template-columns: 1fr; }
 }
+
+
+/* Single-column + restore rules when privacy is hidden */
+main.no-privacy{
+  grid-template-columns: minmax(0,1fr) !important; /* one column */
+  grid-auto-flow: row dense;
+}
+main.no-privacy > #work-card{
+  grid-column: 1 / -1; /* span full width */
+  width: 100%;
+}
+main.no-privacy > #privacy-card{
+  display: none !important; /* hide privacy card entirely */
+}
+/* Make the “Documents we can help with” full-width and place it at top when privacy hidden */
+main.no-privacy > #help-card.fullwidth-help{
+  grid-column: 1 / -1;
+  width: 100%;
+  margin-bottom: 16px;
+}
 </style>
 </head>
 <body>
@@ -311,7 +331,7 @@ main.no-privacy > #privacy-card{
     </div>
   </details>
 
-  <div style="grid-column:2;">
+  <div style="grid-column:2;" id="help-card">
     <h3 style="margin-top:18px;" id="seo-title">Documents we can help with</h3>
     <p class="legal" id="seo-text">Contracts, rental agreements, utility bills, bank letters, insurance terms, general conditions, and more.</p>
   </div>

--- a/fr/index.html
+++ b/fr/index.html
@@ -193,6 +193,26 @@ main.no-privacy > #privacy-card{
 @media (max-width: 980px){
   main{ grid-template-columns: 1fr; }
 }
+
+
+/* Single-column + restore rules when privacy is hidden */
+main.no-privacy{
+  grid-template-columns: minmax(0,1fr) !important; /* one column */
+  grid-auto-flow: row dense;
+}
+main.no-privacy > #work-card{
+  grid-column: 1 / -1; /* span full width */
+  width: 100%;
+}
+main.no-privacy > #privacy-card{
+  display: none !important; /* hide privacy card entirely */
+}
+/* Make the “Documents we can help with” full-width and place it at top when privacy hidden */
+main.no-privacy > #help-card.fullwidth-help{
+  grid-column: 1 / -1;
+  width: 100%;
+  margin-bottom: 16px;
+}
 </style>
 </head>
 <body>
@@ -311,7 +331,7 @@ main.no-privacy > #privacy-card{
     </div>
   </details>
 
-  <div style="grid-column:2;">
+  <div style="grid-column:2;" id="help-card">
     <h3 style="margin-top:18px;" id="seo-title">Documents we can help with</h3>
     <p class="legal" id="seo-text">Contracts, rental agreements, utility bills, bank letters, insurance terms, general conditions, and more.</p>
   </div>

--- a/hi/index.html
+++ b/hi/index.html
@@ -193,6 +193,26 @@ main.no-privacy > #privacy-card{
 @media (max-width: 980px){
   main{ grid-template-columns: 1fr; }
 }
+
+
+/* Single-column + restore rules when privacy is hidden */
+main.no-privacy{
+  grid-template-columns: minmax(0,1fr) !important; /* one column */
+  grid-auto-flow: row dense;
+}
+main.no-privacy > #work-card{
+  grid-column: 1 / -1; /* span full width */
+  width: 100%;
+}
+main.no-privacy > #privacy-card{
+  display: none !important; /* hide privacy card entirely */
+}
+/* Make the “Documents we can help with” full-width and place it at top when privacy hidden */
+main.no-privacy > #help-card.fullwidth-help{
+  grid-column: 1 / -1;
+  width: 100%;
+  margin-bottom: 16px;
+}
 </style>
 </head>
 <body>
@@ -311,7 +331,7 @@ main.no-privacy > #privacy-card{
     </div>
   </details>
 
-  <div style="grid-column:2;">
+  <div style="grid-column:2;" id="help-card">
     <h3 style="margin-top:18px;" id="seo-title">Documents we can help with</h3>
     <p class="legal" id="seo-text">Contracts, rental agreements, utility bills, bank letters, insurance terms, general conditions, and more.</p>
   </div>

--- a/index.html
+++ b/index.html
@@ -193,6 +193,26 @@ main.no-privacy > #privacy-card{
 @media (max-width: 980px){
   main{ grid-template-columns: 1fr; }
 }
+
+
+/* Single-column + restore rules when privacy is hidden */
+main.no-privacy{
+  grid-template-columns: minmax(0,1fr) !important; /* one column */
+  grid-auto-flow: row dense;
+}
+main.no-privacy > #work-card{
+  grid-column: 1 / -1; /* span full width */
+  width: 100%;
+}
+main.no-privacy > #privacy-card{
+  display: none !important; /* hide privacy card entirely */
+}
+/* Make the “Documents we can help with” full-width and place it at top when privacy hidden */
+main.no-privacy > #help-card.fullwidth-help{
+  grid-column: 1 / -1;
+  width: 100%;
+  margin-bottom: 16px;
+}
 </style>
 </head>
 <body>
@@ -311,7 +331,7 @@ main.no-privacy > #privacy-card{
     </div>
   </details>
 
-  <div style="grid-column:2;">
+  <div style="grid-column:2;" id="help-card">
     <h3 style="margin-top:18px;" id="seo-title">Documents we can help with</h3>
     <p class="legal" id="seo-text">Contracts, rental agreements, utility bills, bank letters, insurance terms, general conditions, and more.</p>
   </div>

--- a/it/index.html
+++ b/it/index.html
@@ -193,6 +193,26 @@ main.no-privacy > #privacy-card{
 @media (max-width: 980px){
   main{ grid-template-columns: 1fr; }
 }
+
+
+/* Single-column + restore rules when privacy is hidden */
+main.no-privacy{
+  grid-template-columns: minmax(0,1fr) !important; /* one column */
+  grid-auto-flow: row dense;
+}
+main.no-privacy > #work-card{
+  grid-column: 1 / -1; /* span full width */
+  width: 100%;
+}
+main.no-privacy > #privacy-card{
+  display: none !important; /* hide privacy card entirely */
+}
+/* Make the “Documents we can help with” full-width and place it at top when privacy hidden */
+main.no-privacy > #help-card.fullwidth-help{
+  grid-column: 1 / -1;
+  width: 100%;
+  margin-bottom: 16px;
+}
 </style>
 </head>
 <body>
@@ -311,7 +331,7 @@ main.no-privacy > #privacy-card{
     </div>
   </details>
 
-  <div style="grid-column:2;">
+  <div style="grid-column:2;" id="help-card">
     <h3 style="margin-top:18px;" id="seo-title">Documents we can help with</h3>
     <p class="legal" id="seo-text">Contracts, rental agreements, utility bills, bank letters, insurance terms, general conditions, and more.</p>
   </div>

--- a/pt/index.html
+++ b/pt/index.html
@@ -193,6 +193,26 @@ main.no-privacy > #privacy-card{
 @media (max-width: 980px){
   main{ grid-template-columns: 1fr; }
 }
+
+
+/* Single-column + restore rules when privacy is hidden */
+main.no-privacy{
+  grid-template-columns: minmax(0,1fr) !important; /* one column */
+  grid-auto-flow: row dense;
+}
+main.no-privacy > #work-card{
+  grid-column: 1 / -1; /* span full width */
+  width: 100%;
+}
+main.no-privacy > #privacy-card{
+  display: none !important; /* hide privacy card entirely */
+}
+/* Make the “Documents we can help with” full-width and place it at top when privacy hidden */
+main.no-privacy > #help-card.fullwidth-help{
+  grid-column: 1 / -1;
+  width: 100%;
+  margin-bottom: 16px;
+}
 </style>
 </head>
 <body>
@@ -311,7 +331,7 @@ main.no-privacy > #privacy-card{
     </div>
   </details>
 
-  <div style="grid-column:2;">
+  <div style="grid-column:2;" id="help-card">
     <h3 style="margin-top:18px;" id="seo-title">Documents we can help with</h3>
     <p class="legal" id="seo-text">Contracts, rental agreements, utility bills, bank letters, insurance terms, general conditions, and more.</p>
   </div>

--- a/ru/index.html
+++ b/ru/index.html
@@ -193,6 +193,26 @@ main.no-privacy > #privacy-card{
 @media (max-width: 980px){
   main{ grid-template-columns: 1fr; }
 }
+
+
+/* Single-column + restore rules when privacy is hidden */
+main.no-privacy{
+  grid-template-columns: minmax(0,1fr) !important; /* one column */
+  grid-auto-flow: row dense;
+}
+main.no-privacy > #work-card{
+  grid-column: 1 / -1; /* span full width */
+  width: 100%;
+}
+main.no-privacy > #privacy-card{
+  display: none !important; /* hide privacy card entirely */
+}
+/* Make the “Documents we can help with” full-width and place it at top when privacy hidden */
+main.no-privacy > #help-card.fullwidth-help{
+  grid-column: 1 / -1;
+  width: 100%;
+  margin-bottom: 16px;
+}
 </style>
 </head>
 <body>
@@ -311,7 +331,7 @@ main.no-privacy > #privacy-card{
     </div>
   </details>
 
-  <div style="grid-column:2;">
+  <div style="grid-column:2;" id="help-card">
     <h3 style="margin-top:18px;" id="seo-title">Documents we can help with</h3>
     <p class="legal" id="seo-text">Contracts, rental agreements, utility bills, bank letters, insurance terms, general conditions, and more.</p>
   </div>

--- a/scripts/privacy-fab.js
+++ b/scripts/privacy-fab.js
@@ -20,6 +20,9 @@
             || panel.querySelector('[data-privacy-hide]')
             || panel.querySelector('button, a'); // last resort if your header has a single "Hide" control
   var main = document.querySelector('main');
+  var help = document.getElementById('help-card');
+  var helpParent = help ? help.parentNode : null;
+  var helpNext = help ? help.nextSibling : null; // to restore exact DOM position
 
   // create the floating FAB
   var fab = document.getElementById('privacy-fab');
@@ -37,6 +40,21 @@
   function applyState(open) {
     if (panel) panel.style.display = open ? '' : 'none';
     if (main)  main.classList.toggle('no-privacy', !open);
+    if (help) {
+      if (!open) {
+        // move to top and make it full-width
+        help.classList.add('fullwidth-help');
+        if (main && help !== main.firstElementChild) {
+          try { main.prepend(help); } catch(e){}
+        }
+      } else {
+        // restore to original position and width
+        help.classList.remove('fullwidth-help');
+        if (helpParent) {
+          try { helpParent.insertBefore(help, helpNext); } catch(e){}
+        }
+      }
+    }
     fab.hidden = !!open;
     fab.setAttribute('aria-expanded', open ? 'true':'false');
     fab.setAttribute('title', open ? HIDE : SHOW);

--- a/zh/index.html
+++ b/zh/index.html
@@ -193,6 +193,26 @@ main.no-privacy > #privacy-card{
 @media (max-width: 980px){
   main{ grid-template-columns: 1fr; }
 }
+
+
+/* Single-column + restore rules when privacy is hidden */
+main.no-privacy{
+  grid-template-columns: minmax(0,1fr) !important; /* one column */
+  grid-auto-flow: row dense;
+}
+main.no-privacy > #work-card{
+  grid-column: 1 / -1; /* span full width */
+  width: 100%;
+}
+main.no-privacy > #privacy-card{
+  display: none !important; /* hide privacy card entirely */
+}
+/* Make the “Documents we can help with” full-width and place it at top when privacy hidden */
+main.no-privacy > #help-card.fullwidth-help{
+  grid-column: 1 / -1;
+  width: 100%;
+  margin-bottom: 16px;
+}
 </style>
 </head>
 <body>
@@ -311,7 +331,7 @@ main.no-privacy > #privacy-card{
     </div>
   </details>
 
-  <div style="grid-column:2;">
+  <div style="grid-column:2;" id="help-card">
     <h3 style="margin-top:18px;" id="seo-title">Documents we can help with</h3>
     <p class="legal" id="seo-text">Contracts, rental agreements, utility bills, bank letters, insurance terms, general conditions, and more.</p>
   </div>


### PR DESCRIPTION
## Summary
- give "Documents we can help with" card an id across all languages
- on privacy hide, make main single-column and move card to top full-width
- restore card position and width when privacy is shown

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68be9a630d848329aaca2448504f2369