### PR TITLE
Hide help card on mobile when privacy panel hidden

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -213,6 +213,13 @@ main.no-privacy > #help-card.fullwidth-help{
   width: 100%;
   margin-bottom: 16px;
 }
+
+@media (max-width: 980px){
+  /* On phone/tablet, if privacy is hidden, fully hide the help card */
+  main.no-privacy > #help-card {
+    display: none !important;
+  }
+}
 </style>
 </head>
 <body>

--- a/bn/index.html
+++ b/bn/index.html
@@ -213,6 +213,13 @@ main.no-privacy > #help-card.fullwidth-help{
   width: 100%;
   margin-bottom: 16px;
 }
+
+@media (max-width: 980px){
+  /* On phone/tablet, if privacy is hidden, fully hide the help card */
+  main.no-privacy > #help-card {
+    display: none !important;
+  }
+}
 </style>
 </head>
 <body>

--- a/de/index.html
+++ b/de/index.html
@@ -213,6 +213,13 @@ main.no-privacy > #help-card.fullwidth-help{
   width: 100%;
   margin-bottom: 16px;
 }
+
+@media (max-width: 980px){
+  /* On phone/tablet, if privacy is hidden, fully hide the help card */
+  main.no-privacy > #help-card {
+    display: none !important;
+  }
+}
 </style>
 </head>
 <body>

--- a/en/index.html
+++ b/en/index.html
@@ -213,6 +213,13 @@ main.no-privacy > #help-card.fullwidth-help{
   width: 100%;
   margin-bottom: 16px;
 }
+
+@media (max-width: 980px){
+  /* On phone/tablet, if privacy is hidden, fully hide the help card */
+  main.no-privacy > #help-card {
+    display: none !important;
+  }
+}
 </style>
 </head>
 <body>

--- a/es/index.html
+++ b/es/index.html
@@ -213,6 +213,13 @@ main.no-privacy > #help-card.fullwidth-help{
   width: 100%;
   margin-bottom: 16px;
 }
+
+@media (max-width: 980px){
+  /* On phone/tablet, if privacy is hidden, fully hide the help card */
+  main.no-privacy > #help-card {
+    display: none !important;
+  }
+}
 </style>
 </head>
 <body>

--- a/fr/index.html
+++ b/fr/index.html
@@ -213,6 +213,13 @@ main.no-privacy > #help-card.fullwidth-help{
   width: 100%;
   margin-bottom: 16px;
 }
+
+@media (max-width: 980px){
+  /* On phone/tablet, if privacy is hidden, fully hide the help card */
+  main.no-privacy > #help-card {
+    display: none !important;
+  }
+}
 </style>
 </head>
 <body>

--- a/hi/index.html
+++ b/hi/index.html
@@ -213,6 +213,13 @@ main.no-privacy > #help-card.fullwidth-help{
   width: 100%;
   margin-bottom: 16px;
 }
+
+@media (max-width: 980px){
+  /* On phone/tablet, if privacy is hidden, fully hide the help card */
+  main.no-privacy > #help-card {
+    display: none !important;
+  }
+}
 </style>
 </head>
 <body>

--- a/index.html
+++ b/index.html
@@ -213,6 +213,13 @@ main.no-privacy > #help-card.fullwidth-help{
   width: 100%;
   margin-bottom: 16px;
 }
+
+@media (max-width: 980px){
+  /* On phone/tablet, if privacy is hidden, fully hide the help card */
+  main.no-privacy > #help-card { 
+    display: none !important;
+  }
+}
 </style>
 </head>
 <body>

--- a/it/index.html
+++ b/it/index.html
@@ -213,6 +213,13 @@ main.no-privacy > #help-card.fullwidth-help{
   width: 100%;
   margin-bottom: 16px;
 }
+
+@media (max-width: 980px){
+  /* On phone/tablet, if privacy is hidden, fully hide the help card */
+  main.no-privacy > #help-card {
+    display: none !important;
+  }
+}
 </style>
 </head>
 <body>

--- a/pt/index.html
+++ b/pt/index.html
@@ -213,6 +213,13 @@ main.no-privacy > #help-card.fullwidth-help{
   width: 100%;
   margin-bottom: 16px;
 }
+
+@media (max-width: 980px){
+  /* On phone/tablet, if privacy is hidden, fully hide the help card */
+  main.no-privacy > #help-card {
+    display: none !important;
+  }
+}
 </style>
 </head>
 <body>

--- a/ru/index.html
+++ b/ru/index.html
@@ -213,6 +213,13 @@ main.no-privacy > #help-card.fullwidth-help{
   width: 100%;
   margin-bottom: 16px;
 }
+
+@media (max-width: 980px){
+  /* On phone/tablet, if privacy is hidden, fully hide the help card */
+  main.no-privacy > #help-card {
+    display: none !important;
+  }
+}
 </style>
 </head>
 <body>

--- a/scripts/privacy-fab.js
+++ b/scripts/privacy-fab.js
@@ -41,14 +41,20 @@
     if (panel) panel.style.display = open ? '' : 'none';
     if (main)  main.classList.toggle('no-privacy', !open);
     if (help) {
+      var isDesktop = window.matchMedia('(min-width: 981px)').matches;
       if (!open) {
-        // move to top and make it full-width
-        help.classList.add('fullwidth-help');
-        if (main && help !== main.firstElementChild) {
-          try { main.prepend(help); } catch(e){}
+        if (isDesktop) {
+          // desktop: move to top and make full width
+          help.classList.add('fullwidth-help');
+          if (main && help !== main.firstElementChild) {
+            try { main.prepend(help); } catch(e){}
+          }
+        } else {
+          // mobile: do not move; CSS will hide it (no space taken)
+          help.classList.remove('fullwidth-help');
         }
       } else {
-        // restore to original position and width
+        // restore original position in all cases
         help.classList.remove('fullwidth-help');
         if (helpParent) {
           try { helpParent.insertBefore(help, helpNext); } catch(e){}
@@ -61,6 +67,11 @@
     fab.textContent = SHOW;
     try { localStorage.setItem('privacy-open', open ? '1' : '0'); } catch(e){}
   }
+
+  try {
+    var mq = window.matchMedia('(min-width: 981px)');
+    mq.addEventListener('change', function(){ applyState(localStorage.getItem('privacy-open') !== '0'); });
+  } catch(e){}
 
   function restore() {
     var s = null;

--- a/zh/index.html
+++ b/zh/index.html
@@ -213,6 +213,13 @@ main.no-privacy > #help-card.fullwidth-help{
   width: 100%;
   margin-bottom: 16px;
 }
+
+@media (max-width: 980px){
+  /* On phone/tablet, if privacy is hidden, fully hide the help card */
+  main.no-privacy > #help-card {
+    display: none !important;
+  }
+}
 </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- hide the help card via CSS on mobile when the privacy section is hidden
- only move the help card to the top and full-width on desktop

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bea43796a48329b0beb41e5764ab72