### PR TITLE
style(layout): move help card above work card when privacy hidden

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -189,37 +189,31 @@ main.no-privacy > #privacy-card{
   display: none !important; /* ensure no ghost column */
 }
 
-/* Mobile already uses 1 column, keep it explicit */
-@media (max-width: 980px){
-  main{ grid-template-columns: 1fr; }
-}
 
-
-/* Single-column + restore rules when privacy is hidden */
+/* When privacy is hidden, collapse to one column */
 main.no-privacy{
-  grid-template-columns: minmax(0,1fr) !important; /* one column */
+  grid-template-columns: minmax(0,1fr) !important;
   grid-auto-flow: row dense;
 }
-main.no-privacy > #work-card{
-  grid-column: 1 / -1; /* span full width */
-  width: 100%;
-}
-main.no-privacy > #privacy-card{
-  display: none !important; /* hide privacy card entirely */
-}
-/* Make the “Documents we can help with” full-width and place it at top when privacy hidden */
-main.no-privacy > #help-card.fullwidth-help{
+main.no-privacy > #privacy-card{ display:none !important; }
+
+/* Help card becomes full width and sits above the work card */
+main.no-privacy #help-card.fullwidth-help{
   grid-column: 1 / -1;
   width: 100%;
   margin-bottom: 16px;
 }
 
-@media (max-width: 980px){
-  /* On phone/tablet, if privacy is hidden, fully hide the help card */
-  main.no-privacy > #help-card {
-    display: none !important;
-  }
+/* Ensure the left card spans full width */
+main.no-privacy #work-card{
+  grid-column: 1 / -1;
+  width: 100%;
 }
+
+@media (max-width: 980px){
+  main{ grid-template-columns: 1fr; } /* explicit on mobile */
+}
+
 </style>
 </head>
 <body>

--- a/bn/index.html
+++ b/bn/index.html
@@ -189,37 +189,31 @@ main.no-privacy > #privacy-card{
   display: none !important; /* ensure no ghost column */
 }
 
-/* Mobile already uses 1 column, keep it explicit */
-@media (max-width: 980px){
-  main{ grid-template-columns: 1fr; }
-}
 
-
-/* Single-column + restore rules when privacy is hidden */
+/* When privacy is hidden, collapse to one column */
 main.no-privacy{
-  grid-template-columns: minmax(0,1fr) !important; /* one column */
+  grid-template-columns: minmax(0,1fr) !important;
   grid-auto-flow: row dense;
 }
-main.no-privacy > #work-card{
-  grid-column: 1 / -1; /* span full width */
-  width: 100%;
-}
-main.no-privacy > #privacy-card{
-  display: none !important; /* hide privacy card entirely */
-}
-/* Make the “Documents we can help with” full-width and place it at top when privacy hidden */
-main.no-privacy > #help-card.fullwidth-help{
+main.no-privacy > #privacy-card{ display:none !important; }
+
+/* Help card becomes full width and sits above the work card */
+main.no-privacy #help-card.fullwidth-help{
   grid-column: 1 / -1;
   width: 100%;
   margin-bottom: 16px;
 }
 
-@media (max-width: 980px){
-  /* On phone/tablet, if privacy is hidden, fully hide the help card */
-  main.no-privacy > #help-card {
-    display: none !important;
-  }
+/* Ensure the left card spans full width */
+main.no-privacy #work-card{
+  grid-column: 1 / -1;
+  width: 100%;
 }
+
+@media (max-width: 980px){
+  main{ grid-template-columns: 1fr; } /* explicit on mobile */
+}
+
 </style>
 </head>
 <body>

--- a/de/index.html
+++ b/de/index.html
@@ -189,37 +189,31 @@ main.no-privacy > #privacy-card{
   display: none !important; /* ensure no ghost column */
 }
 
-/* Mobile already uses 1 column, keep it explicit */
-@media (max-width: 980px){
-  main{ grid-template-columns: 1fr; }
-}
 
-
-/* Single-column + restore rules when privacy is hidden */
+/* When privacy is hidden, collapse to one column */
 main.no-privacy{
-  grid-template-columns: minmax(0,1fr) !important; /* one column */
+  grid-template-columns: minmax(0,1fr) !important;
   grid-auto-flow: row dense;
 }
-main.no-privacy > #work-card{
-  grid-column: 1 / -1; /* span full width */
-  width: 100%;
-}
-main.no-privacy > #privacy-card{
-  display: none !important; /* hide privacy card entirely */
-}
-/* Make the “Documents we can help with” full-width and place it at top when privacy hidden */
-main.no-privacy > #help-card.fullwidth-help{
+main.no-privacy > #privacy-card{ display:none !important; }
+
+/* Help card becomes full width and sits above the work card */
+main.no-privacy #help-card.fullwidth-help{
   grid-column: 1 / -1;
   width: 100%;
   margin-bottom: 16px;
 }
 
-@media (max-width: 980px){
-  /* On phone/tablet, if privacy is hidden, fully hide the help card */
-  main.no-privacy > #help-card {
-    display: none !important;
-  }
+/* Ensure the left card spans full width */
+main.no-privacy #work-card{
+  grid-column: 1 / -1;
+  width: 100%;
 }
+
+@media (max-width: 980px){
+  main{ grid-template-columns: 1fr; } /* explicit on mobile */
+}
+
 </style>
 </head>
 <body>

--- a/en/index.html
+++ b/en/index.html
@@ -189,37 +189,31 @@ main.no-privacy > #privacy-card{
   display: none !important; /* ensure no ghost column */
 }
 
-/* Mobile already uses 1 column, keep it explicit */
-@media (max-width: 980px){
-  main{ grid-template-columns: 1fr; }
-}
 
-
-/* Single-column + restore rules when privacy is hidden */
+/* When privacy is hidden, collapse to one column */
 main.no-privacy{
-  grid-template-columns: minmax(0,1fr) !important; /* one column */
+  grid-template-columns: minmax(0,1fr) !important;
   grid-auto-flow: row dense;
 }
-main.no-privacy > #work-card{
-  grid-column: 1 / -1; /* span full width */
-  width: 100%;
-}
-main.no-privacy > #privacy-card{
-  display: none !important; /* hide privacy card entirely */
-}
-/* Make the “Documents we can help with” full-width and place it at top when privacy hidden */
-main.no-privacy > #help-card.fullwidth-help{
+main.no-privacy > #privacy-card{ display:none !important; }
+
+/* Help card becomes full width and sits above the work card */
+main.no-privacy #help-card.fullwidth-help{
   grid-column: 1 / -1;
   width: 100%;
   margin-bottom: 16px;
 }
 
-@media (max-width: 980px){
-  /* On phone/tablet, if privacy is hidden, fully hide the help card */
-  main.no-privacy > #help-card {
-    display: none !important;
-  }
+/* Ensure the left card spans full width */
+main.no-privacy #work-card{
+  grid-column: 1 / -1;
+  width: 100%;
 }
+
+@media (max-width: 980px){
+  main{ grid-template-columns: 1fr; } /* explicit on mobile */
+}
+
 </style>
 </head>
 <body>

--- a/es/index.html
+++ b/es/index.html
@@ -189,37 +189,31 @@ main.no-privacy > #privacy-card{
   display: none !important; /* ensure no ghost column */
 }
 
-/* Mobile already uses 1 column, keep it explicit */
-@media (max-width: 980px){
-  main{ grid-template-columns: 1fr; }
-}
 
-
-/* Single-column + restore rules when privacy is hidden */
+/* When privacy is hidden, collapse to one column */
 main.no-privacy{
-  grid-template-columns: minmax(0,1fr) !important; /* one column */
+  grid-template-columns: minmax(0,1fr) !important;
   grid-auto-flow: row dense;
 }
-main.no-privacy > #work-card{
-  grid-column: 1 / -1; /* span full width */
-  width: 100%;
-}
-main.no-privacy > #privacy-card{
-  display: none !important; /* hide privacy card entirely */
-}
-/* Make the “Documents we can help with” full-width and place it at top when privacy hidden */
-main.no-privacy > #help-card.fullwidth-help{
+main.no-privacy > #privacy-card{ display:none !important; }
+
+/* Help card becomes full width and sits above the work card */
+main.no-privacy #help-card.fullwidth-help{
   grid-column: 1 / -1;
   width: 100%;
   margin-bottom: 16px;
 }
 
-@media (max-width: 980px){
-  /* On phone/tablet, if privacy is hidden, fully hide the help card */
-  main.no-privacy > #help-card {
-    display: none !important;
-  }
+/* Ensure the left card spans full width */
+main.no-privacy #work-card{
+  grid-column: 1 / -1;
+  width: 100%;
 }
+
+@media (max-width: 980px){
+  main{ grid-template-columns: 1fr; } /* explicit on mobile */
+}
+
 </style>
 </head>
 <body>

--- a/fr/index.html
+++ b/fr/index.html
@@ -189,37 +189,31 @@ main.no-privacy > #privacy-card{
   display: none !important; /* ensure no ghost column */
 }
 
-/* Mobile already uses 1 column, keep it explicit */
-@media (max-width: 980px){
-  main{ grid-template-columns: 1fr; }
-}
 
-
-/* Single-column + restore rules when privacy is hidden */
+/* When privacy is hidden, collapse to one column */
 main.no-privacy{
-  grid-template-columns: minmax(0,1fr) !important; /* one column */
+  grid-template-columns: minmax(0,1fr) !important;
   grid-auto-flow: row dense;
 }
-main.no-privacy > #work-card{
-  grid-column: 1 / -1; /* span full width */
-  width: 100%;
-}
-main.no-privacy > #privacy-card{
-  display: none !important; /* hide privacy card entirely */
-}
-/* Make the “Documents we can help with” full-width and place it at top when privacy hidden */
-main.no-privacy > #help-card.fullwidth-help{
+main.no-privacy > #privacy-card{ display:none !important; }
+
+/* Help card becomes full width and sits above the work card */
+main.no-privacy #help-card.fullwidth-help{
   grid-column: 1 / -1;
   width: 100%;
   margin-bottom: 16px;
 }
 
-@media (max-width: 980px){
-  /* On phone/tablet, if privacy is hidden, fully hide the help card */
-  main.no-privacy > #help-card {
-    display: none !important;
-  }
+/* Ensure the left card spans full width */
+main.no-privacy #work-card{
+  grid-column: 1 / -1;
+  width: 100%;
 }
+
+@media (max-width: 980px){
+  main{ grid-template-columns: 1fr; } /* explicit on mobile */
+}
+
 </style>
 </head>
 <body>

--- a/hi/index.html
+++ b/hi/index.html
@@ -189,37 +189,31 @@ main.no-privacy > #privacy-card{
   display: none !important; /* ensure no ghost column */
 }
 
-/* Mobile already uses 1 column, keep it explicit */
-@media (max-width: 980px){
-  main{ grid-template-columns: 1fr; }
-}
 
-
-/* Single-column + restore rules when privacy is hidden */
+/* When privacy is hidden, collapse to one column */
 main.no-privacy{
-  grid-template-columns: minmax(0,1fr) !important; /* one column */
+  grid-template-columns: minmax(0,1fr) !important;
   grid-auto-flow: row dense;
 }
-main.no-privacy > #work-card{
-  grid-column: 1 / -1; /* span full width */
-  width: 100%;
-}
-main.no-privacy > #privacy-card{
-  display: none !important; /* hide privacy card entirely */
-}
-/* Make the “Documents we can help with” full-width and place it at top when privacy hidden */
-main.no-privacy > #help-card.fullwidth-help{
+main.no-privacy > #privacy-card{ display:none !important; }
+
+/* Help card becomes full width and sits above the work card */
+main.no-privacy #help-card.fullwidth-help{
   grid-column: 1 / -1;
   width: 100%;
   margin-bottom: 16px;
 }
 
-@media (max-width: 980px){
-  /* On phone/tablet, if privacy is hidden, fully hide the help card */
-  main.no-privacy > #help-card {
-    display: none !important;
-  }
+/* Ensure the left card spans full width */
+main.no-privacy #work-card{
+  grid-column: 1 / -1;
+  width: 100%;
 }
+
+@media (max-width: 980px){
+  main{ grid-template-columns: 1fr; } /* explicit on mobile */
+}
+
 </style>
 </head>
 <body>

--- a/index.html
+++ b/index.html
@@ -189,37 +189,31 @@ main.no-privacy > #privacy-card{
   display: none !important; /* ensure no ghost column */
 }
 
-/* Mobile already uses 1 column, keep it explicit */
-@media (max-width: 980px){
-  main{ grid-template-columns: 1fr; }
-}
 
-
-/* Single-column + restore rules when privacy is hidden */
+/* When privacy is hidden, collapse to one column */
 main.no-privacy{
-  grid-template-columns: minmax(0,1fr) !important; /* one column */
+  grid-template-columns: minmax(0,1fr) !important;
   grid-auto-flow: row dense;
 }
-main.no-privacy > #work-card{
-  grid-column: 1 / -1; /* span full width */
-  width: 100%;
-}
-main.no-privacy > #privacy-card{
-  display: none !important; /* hide privacy card entirely */
-}
-/* Make the “Documents we can help with” full-width and place it at top when privacy hidden */
-main.no-privacy > #help-card.fullwidth-help{
+main.no-privacy > #privacy-card{ display:none !important; }
+
+/* Help card becomes full width and sits above the work card */
+main.no-privacy #help-card.fullwidth-help{
   grid-column: 1 / -1;
   width: 100%;
   margin-bottom: 16px;
 }
 
-@media (max-width: 980px){
-  /* On phone/tablet, if privacy is hidden, fully hide the help card */
-  main.no-privacy > #help-card { 
-    display: none !important;
-  }
+/* Ensure the left card spans full width */
+main.no-privacy #work-card{
+  grid-column: 1 / -1;
+  width: 100%;
 }
+
+@media (max-width: 980px){
+  main{ grid-template-columns: 1fr; } /* explicit on mobile */
+}
+
 </style>
 </head>
 <body>

--- a/it/index.html
+++ b/it/index.html
@@ -189,37 +189,31 @@ main.no-privacy > #privacy-card{
   display: none !important; /* ensure no ghost column */
 }
 
-/* Mobile already uses 1 column, keep it explicit */
-@media (max-width: 980px){
-  main{ grid-template-columns: 1fr; }
-}
 
-
-/* Single-column + restore rules when privacy is hidden */
+/* When privacy is hidden, collapse to one column */
 main.no-privacy{
-  grid-template-columns: minmax(0,1fr) !important; /* one column */
+  grid-template-columns: minmax(0,1fr) !important;
   grid-auto-flow: row dense;
 }
-main.no-privacy > #work-card{
-  grid-column: 1 / -1; /* span full width */
-  width: 100%;
-}
-main.no-privacy > #privacy-card{
-  display: none !important; /* hide privacy card entirely */
-}
-/* Make the “Documents we can help with” full-width and place it at top when privacy hidden */
-main.no-privacy > #help-card.fullwidth-help{
+main.no-privacy > #privacy-card{ display:none !important; }
+
+/* Help card becomes full width and sits above the work card */
+main.no-privacy #help-card.fullwidth-help{
   grid-column: 1 / -1;
   width: 100%;
   margin-bottom: 16px;
 }
 
-@media (max-width: 980px){
-  /* On phone/tablet, if privacy is hidden, fully hide the help card */
-  main.no-privacy > #help-card {
-    display: none !important;
-  }
+/* Ensure the left card spans full width */
+main.no-privacy #work-card{
+  grid-column: 1 / -1;
+  width: 100%;
 }
+
+@media (max-width: 980px){
+  main{ grid-template-columns: 1fr; } /* explicit on mobile */
+}
+
 </style>
 </head>
 <body>

--- a/pt/index.html
+++ b/pt/index.html
@@ -189,37 +189,31 @@ main.no-privacy > #privacy-card{
   display: none !important; /* ensure no ghost column */
 }
 
-/* Mobile already uses 1 column, keep it explicit */
-@media (max-width: 980px){
-  main{ grid-template-columns: 1fr; }
-}
 
-
-/* Single-column + restore rules when privacy is hidden */
+/* When privacy is hidden, collapse to one column */
 main.no-privacy{
-  grid-template-columns: minmax(0,1fr) !important; /* one column */
+  grid-template-columns: minmax(0,1fr) !important;
   grid-auto-flow: row dense;
 }
-main.no-privacy > #work-card{
-  grid-column: 1 / -1; /* span full width */
-  width: 100%;
-}
-main.no-privacy > #privacy-card{
-  display: none !important; /* hide privacy card entirely */
-}
-/* Make the “Documents we can help with” full-width and place it at top when privacy hidden */
-main.no-privacy > #help-card.fullwidth-help{
+main.no-privacy > #privacy-card{ display:none !important; }
+
+/* Help card becomes full width and sits above the work card */
+main.no-privacy #help-card.fullwidth-help{
   grid-column: 1 / -1;
   width: 100%;
   margin-bottom: 16px;
 }
 
-@media (max-width: 980px){
-  /* On phone/tablet, if privacy is hidden, fully hide the help card */
-  main.no-privacy > #help-card {
-    display: none !important;
-  }
+/* Ensure the left card spans full width */
+main.no-privacy #work-card{
+  grid-column: 1 / -1;
+  width: 100%;
 }
+
+@media (max-width: 980px){
+  main{ grid-template-columns: 1fr; } /* explicit on mobile */
+}
+
 </style>
 </head>
 <body>

--- a/ru/index.html
+++ b/ru/index.html
@@ -189,37 +189,31 @@ main.no-privacy > #privacy-card{
   display: none !important; /* ensure no ghost column */
 }
 
-/* Mobile already uses 1 column, keep it explicit */
-@media (max-width: 980px){
-  main{ grid-template-columns: 1fr; }
-}
 
-
-/* Single-column + restore rules when privacy is hidden */
+/* When privacy is hidden, collapse to one column */
 main.no-privacy{
-  grid-template-columns: minmax(0,1fr) !important; /* one column */
+  grid-template-columns: minmax(0,1fr) !important;
   grid-auto-flow: row dense;
 }
-main.no-privacy > #work-card{
-  grid-column: 1 / -1; /* span full width */
-  width: 100%;
-}
-main.no-privacy > #privacy-card{
-  display: none !important; /* hide privacy card entirely */
-}
-/* Make the “Documents we can help with” full-width and place it at top when privacy hidden */
-main.no-privacy > #help-card.fullwidth-help{
+main.no-privacy > #privacy-card{ display:none !important; }
+
+/* Help card becomes full width and sits above the work card */
+main.no-privacy #help-card.fullwidth-help{
   grid-column: 1 / -1;
   width: 100%;
   margin-bottom: 16px;
 }
 
-@media (max-width: 980px){
-  /* On phone/tablet, if privacy is hidden, fully hide the help card */
-  main.no-privacy > #help-card {
-    display: none !important;
-  }
+/* Ensure the left card spans full width */
+main.no-privacy #work-card{
+  grid-column: 1 / -1;
+  width: 100%;
 }
+
+@media (max-width: 980px){
+  main{ grid-template-columns: 1fr; } /* explicit on mobile */
+}
+
 </style>
 </head>
 <body>

--- a/scripts/privacy-fab.js
+++ b/scripts/privacy-fab.js
@@ -20,9 +20,10 @@
             || panel.querySelector('[data-privacy-hide]')
             || panel.querySelector('button, a'); // last resort if your header has a single "Hide" control
   var main = document.querySelector('main');
-  var help = document.getElementById('help-card');
+  var help = document.getElementById('help-card') || document.querySelector('#help-card');
+  var work = document.getElementById('work-card') || document.querySelector('#work-card');
   var helpParent = help ? help.parentNode : null;
-  var helpNext = help ? help.nextSibling : null; // to restore exact DOM position
+  var helpNext   = help ? help.nextSibling : null;
 
   // create the floating FAB
   var fab = document.getElementById('privacy-fab');
@@ -41,20 +42,17 @@
     if (panel) panel.style.display = open ? '' : 'none';
     if (main)  main.classList.toggle('no-privacy', !open);
     if (help) {
-      var isDesktop = window.matchMedia('(min-width: 981px)').matches;
       if (!open) {
-        if (isDesktop) {
-          // desktop: move to top and make full width
-          help.classList.add('fullwidth-help');
-          if (main && help !== main.firstElementChild) {
-            try { main.prepend(help); } catch(e){}
-          }
-        } else {
-          // mobile: do not move; CSS will hide it (no space taken)
-          help.classList.remove('fullwidth-help');
+        // Privacy hidden -> single column
+        // Move HELP INSIDE LEFT COLUMN, ABOVE the work card
+        help.classList.add('fullwidth-help');
+        if (work && work.parentNode) {
+          try { work.parentNode.insertBefore(help, work); } catch(e){}
+        } else if (main) {
+          try { main.prepend(help); } catch(e){}
         }
       } else {
-        // restore original position in all cases
+        // Restore original position
         help.classList.remove('fullwidth-help');
         if (helpParent) {
           try { helpParent.insertBefore(help, helpNext); } catch(e){}

--- a/zh/index.html
+++ b/zh/index.html
@@ -189,37 +189,31 @@ main.no-privacy > #privacy-card{
   display: none !important; /* ensure no ghost column */
 }
 
-/* Mobile already uses 1 column, keep it explicit */
-@media (max-width: 980px){
-  main{ grid-template-columns: 1fr; }
-}
 
-
-/* Single-column + restore rules when privacy is hidden */
+/* When privacy is hidden, collapse to one column */
 main.no-privacy{
-  grid-template-columns: minmax(0,1fr) !important; /* one column */
+  grid-template-columns: minmax(0,1fr) !important;
   grid-auto-flow: row dense;
 }
-main.no-privacy > #work-card{
-  grid-column: 1 / -1; /* span full width */
-  width: 100%;
-}
-main.no-privacy > #privacy-card{
-  display: none !important; /* hide privacy card entirely */
-}
-/* Make the “Documents we can help with” full-width and place it at top when privacy hidden */
-main.no-privacy > #help-card.fullwidth-help{
+main.no-privacy > #privacy-card{ display:none !important; }
+
+/* Help card becomes full width and sits above the work card */
+main.no-privacy #help-card.fullwidth-help{
   grid-column: 1 / -1;
   width: 100%;
   margin-bottom: 16px;
 }
 
-@media (max-width: 980px){
-  /* On phone/tablet, if privacy is hidden, fully hide the help card */
-  main.no-privacy > #help-card {
-    display: none !important;
-  }
+/* Ensure the left card spans full width */
+main.no-privacy #work-card{
+  grid-column: 1 / -1;
+  width: 100%;
 }
+
+@media (max-width: 980px){
+  main{ grid-template-columns: 1fr; } /* explicit on mobile */
+}
+
 </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- Move help card above left work card and make it full width when privacy panel is hidden
- Collapse main layout to single column when privacy panel hidden and restore on show
- Keep privacy toggling logic and add DOM restoration when panel is shown

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bea854b2a88329b6acb1a59aca82f5