### PR TITLE
chore(rewrites): add clean topic URLs for one-page intents (bill/contract EN+FR)

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -39,7 +39,11 @@
     { "source": "/ru/", "destination": "/ru/index.html" },
 
     { "source": "/zh",  "destination": "/zh/index.html" },
-    { "source": "/zh/", "destination": "/zh/index.html" }
+    { "source": "/zh/", "destination": "/zh/index.html" },
+    { "source": "/explain/bill",       "destination": "/?topic=bill" },
+    { "source": "/explain/contract",   "destination": "/?topic=contract" },
+    { "source": "/fr/expliquer/facture","destination": "/fr/?topic=facture" },
+    { "source": "/fr/expliquer/contrat","destination": "/fr/?topic=contrat" }
   ],
 
   "headers": [


### PR DESCRIPTION
## Summary
- expand `vercel.json` rewrites to cover `/explain/bill` and `/explain/contract`
- add French counterparts `/fr/expliquer/facture` and `/fr/expliquer/contrat`

## Testing
- `jq '.rewrites[-6:]' vercel.json`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bebced9df883298cd36693f10993ac