### PR TITLE
feat(seo-fr): one-page topics for facture/contrat with dynamic title/meta/canonical/FAQ/FAQ-JSONLD

### DIFF
--- a/fr/index.html
+++ b/fr/index.html
@@ -269,7 +269,12 @@ main.no-privacy {
       <div class="hero">
         <h2 id="hero-title">Explain contracts, bills & official documents in plain language</h2>
         <p id="hero-sub">Free, private, multilingual. Not legal advice.</p>
-      </div>      <!-- File input (customized & translatable) -->
+      </div>
+      <nav class="topics" id="topics-fr" style="margin:10px 0;">
+        <a href="/fr/expliquer/facture">Expliquer une facture</a> ·
+        <a href="/fr/expliquer/contrat">Expliquer un contrat</a>
+      </nav>
+      <!-- File input (customized & translatable) -->
 <div class="file-row">
   <input type="file" id="file" accept=".pdf,.txt,.docx,.png,.jpg,.jpeg,.webp" class="file-native" />
   <label for="file" class="btn" id="btnChooseFile">Choose a file</label>
@@ -327,6 +332,10 @@ main.no-privacy {
           }
         </script>
       </div>
+    </section>
+    <section class="card" id="faq-card">
+      <h3 id="faq-title">FAQ</h3>
+      <div id="faq"></div>
     </section>
 
       <!-- Privacy & Trust (collapsible, accessible, no-JS needed) -->
@@ -945,6 +954,92 @@ async function ensureHeavyLibs(){
 
   // react when user opens/closes the <details>
   privacy.addEventListener('toggle', applyLayout);
+})();
+</script>
+
+<script>
+(function () {
+  var lang=(document.documentElement.lang||'fr').toLowerCase();
+  var CFG={ fr:{
+    facture:{
+      path:"/fr/expliquer/facture",
+      title:"Expliquer une facture — Gratuit & privé | DocuMate",
+      desc:"Téléversez votre facture ou collez le texte. Explications en langage simple. Multi-langue.",
+      h1:"Expliquer une facture en langage simple",
+      faq:[
+        ["Comment comprendre ma facture ?","Importez le PDF/image ou collez le texte. DocuMate extrait et explique les éléments clés."],
+        ["Est-ce privé ?","Nous ne stockons pas vos documents ; le transfert est chiffré. Vous pouvez enregistrer localement."]
+      ],
+      alternates:[
+        ["en","https://documate.work/explain/bill"],
+        ["fr","https://documate.work/fr/expliquer/facture"],
+        ["x-default","https://documate.work/fr/expliquer/facture"]
+      ]
+    },
+    contrat:{
+      path:"/fr/expliquer/contrat",
+      title:"Expliquer un contrat — Langage simple | DocuMate",
+      desc:"Collez ou importez un contrat et obtenez une explication en langage simple. Pas un conseil juridique.",
+      h1:"Expliquer un contrat en langage simple",
+      faq:[
+        ["Pouvez-vous expliquer une clause ?","Oui, posez une question sur un passage précis ; nous le résumons clairement."]
+      ],
+      alternates:[
+        ["en","https://documate.work/explain/contract"],
+        ["fr","https://documate.work/fr/expliquer/contrat"],
+        ["x-default","https://documate.work/fr/expliquer/contrat"]
+      ]
+    }
+  }};
+
+  function $(s){ return document.querySelector(s); }
+  function setText(sel, txt){ var el=$(sel); if(el && txt) el.textContent=txt; }
+  function setMeta(n, c){ var m=document.querySelector('meta[name="'+n+'"]'); if(m && c) m.setAttribute('content', c); }
+  function setCanonical(u){ var l=document.querySelector('link[rel="canonical"]'); if(l && u) l.setAttribute('href', u); }
+  function injectFAQ(faq){
+    var root=document.getElementById('faq'); if(!root) return;
+    root.innerHTML="";
+    for (var i=0;i<faq.length;i++){
+      var h3=document.createElement('h3'); h3.textContent=faq[i][0];
+      var p=document.createElement('p'); p.textContent=faq[i][1];
+      root.appendChild(h3); root.appendChild(p);
+    }
+  }
+  function injectFAQJsonLD(faq){
+    var ld={"@context":"https://schema.org","@type":"FAQPage","mainEntity":[]};
+    for (var i=0;i<faq.length;i++){
+      ld.mainEntity.push({"@type":"Question","name":faq[i][0],"acceptedAnswer":{"@type":"Answer","text":faq[i][1]}});
+    }
+    var old=document.getElementById('ld-faq'); if(old) old.remove();
+    var s=document.createElement('script'); s.type="application/ld+json"; s.id="ld-faq";
+    try { s.text=JSON.stringify(ld); } catch(e){ return; }
+    document.head.appendChild(s);
+  }
+  function setTopicAlternates(alts){
+    var olds=document.querySelectorAll('link[data-topic-alt="1"]');
+    for (var i=0;i<olds.length;i++) olds[i].remove();
+    for (var j=0;j<alts.length;j++){
+      var l=document.createElement('link');
+      l.setAttribute('rel','alternate');
+      l.setAttribute('hreflang', alts[j][0]);
+      l.setAttribute('href', alts[j][1]);
+      l.setAttribute('data-topic-alt','1');
+      document.head.appendChild(l);
+    }
+  }
+
+  var q=new URLSearchParams(location.search);
+  var key=q.get('topic');
+  var conf=(CFG.fr && CFG.fr[key])? CFG.fr[key] : null;
+  if(!conf) return;
+
+  document.title=conf.title;
+  setMeta('description', conf.desc);
+  setCanonical(location.origin + conf.path);
+  setText('.hero h2', conf.h1);
+  injectFAQ(conf.faq);
+  injectFAQJsonLD(conf.faq);
+  setTopicAlternates(conf.alternates);
 })();
 </script>
 


### PR DESCRIPTION
## Summary
- add topics navigation and FAQ container on French index
- append dynamic SEO script for facture and contrat topics

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bec02844b48329a0df6d1691de7d28