### PR TITLE
chore(sitemap): add one-page intent URLs and drop /en/ duplicate

### DIFF
--- a/sitemap.xml
+++ b/sitemap.xml
@@ -11,4 +11,8 @@
   <url><loc>https://documate.work/ar/</loc></url>
   <url><loc>https://documate.work/ru/</loc></url>
   <url><loc>https://documate.work/bn/</loc></url>
+  <url><loc>https://documate.work/explain/bill</loc></url>
+  <url><loc>https://documate.work/explain/contract</loc></url>
+  <url><loc>https://documate.work/fr/expliquer/facture</loc></url>
+  <url><loc>https://documate.work/fr/expliquer/contrat</loc></url>
 </urlset>


### PR DESCRIPTION
## Summary
- include new explain pages in sitemap and ensure no `/en/` entry remains

## Testing
- `python - <<'PY'
import xml.etree.ElementTree as ET
ET.parse("sitemap.xml")
print("XML OK")
PY`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68bec12148e88329b32b4e0094b1986b