### PR TITLE
perf: defer heavy libs, preconnect ads domains

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -21,6 +21,7 @@
   <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin>
   <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
   <link rel="preconnect" href="https://pagead2.googlesyndication.com" crossorigin>
+  <link rel="preconnect" href="https://googleads.g.doubleclick.net" crossorigin>
 
 
 <!-- Hreflang (static full set) -->
@@ -70,7 +71,7 @@
 </script>
 
   <!-- Mammoth.js (DOCX) -->
-  <script src="https://unpkg.com/mammoth@1.6.0/mammoth.browser.min.js"></script>
+  <script defer src="https://unpkg.com/mammoth@1.6.0/mammoth.browser.min.js"></script>
 
   <style>
     :root { --bg:#f7f9fc; --card:#fff; --ink:#0f172a; --muted:#475569; --accent:#2563eb; --ok:#16a34a; --warn:#b45309; --br:14px; --shadow:0 10px 30px rgba(2,6,23,.08); }

--- a/bn/index.html
+++ b/bn/index.html
@@ -21,6 +21,7 @@
   <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin>
   <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
   <link rel="preconnect" href="https://pagead2.googlesyndication.com" crossorigin>
+  <link rel="preconnect" href="https://googleads.g.doubleclick.net" crossorigin>
 
 
 <!-- Hreflang (static full set) -->
@@ -70,7 +71,7 @@
 </script>
 
   <!-- Mammoth.js (DOCX) -->
-  <script src="https://unpkg.com/mammoth@1.6.0/mammoth.browser.min.js"></script>
+  <script defer src="https://unpkg.com/mammoth@1.6.0/mammoth.browser.min.js"></script>
 
   <style>
     :root { --bg:#f7f9fc; --card:#fff; --ink:#0f172a; --muted:#475569; --accent:#2563eb; --ok:#16a34a; --warn:#b45309; --br:14px; --shadow:0 10px 30px rgba(2,6,23,.08); }

--- a/de/index.html
+++ b/de/index.html
@@ -21,6 +21,7 @@
   <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin>
   <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
   <link rel="preconnect" href="https://pagead2.googlesyndication.com" crossorigin>
+  <link rel="preconnect" href="https://googleads.g.doubleclick.net" crossorigin>
 
 
 <!-- Hreflang (static full set) -->
@@ -70,7 +71,7 @@
 </script>
 
   <!-- Mammoth.js (DOCX) -->
-  <script src="https://unpkg.com/mammoth@1.6.0/mammoth.browser.min.js"></script>
+  <script defer src="https://unpkg.com/mammoth@1.6.0/mammoth.browser.min.js"></script>
 
   <style>
     :root { --bg:#f7f9fc; --card:#fff; --ink:#0f172a; --muted:#475569; --accent:#2563eb; --ok:#16a34a; --warn:#b45309; --br:14px; --shadow:0 10px 30px rgba(2,6,23,.08); }

--- a/en/index.html
+++ b/en/index.html
@@ -21,6 +21,7 @@
   <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin>
   <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
   <link rel="preconnect" href="https://pagead2.googlesyndication.com" crossorigin>
+  <link rel="preconnect" href="https://googleads.g.doubleclick.net" crossorigin>
 
 
 <!-- Hreflang (static full set) -->
@@ -70,7 +71,7 @@
 </script>
 
   <!-- Mammoth.js (DOCX) -->
-  <script src="https://unpkg.com/mammoth@1.6.0/mammoth.browser.min.js"></script>
+  <script defer src="https://unpkg.com/mammoth@1.6.0/mammoth.browser.min.js"></script>
 
   <style>
     :root { --bg:#f7f9fc; --card:#fff; --ink:#0f172a; --muted:#475569; --accent:#2563eb; --ok:#16a34a; --warn:#b45309; --br:14px; --shadow:0 10px 30px rgba(2,6,23,.08); }

--- a/es/index.html
+++ b/es/index.html
@@ -21,6 +21,7 @@
   <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin>
   <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
   <link rel="preconnect" href="https://pagead2.googlesyndication.com" crossorigin>
+  <link rel="preconnect" href="https://googleads.g.doubleclick.net" crossorigin>
 
 
 <!-- Hreflang (static full set) -->
@@ -70,7 +71,7 @@
 </script>
 
   <!-- Mammoth.js (DOCX) -->
-  <script src="https://unpkg.com/mammoth@1.6.0/mammoth.browser.min.js"></script>
+  <script defer src="https://unpkg.com/mammoth@1.6.0/mammoth.browser.min.js"></script>
 
   <style>
     :root { --bg:#f7f9fc; --card:#fff; --ink:#0f172a; --muted:#475569; --accent:#2563eb; --ok:#16a34a; --warn:#b45309; --br:14px; --shadow:0 10px 30px rgba(2,6,23,.08); }

--- a/fr/index.html
+++ b/fr/index.html
@@ -21,6 +21,7 @@
   <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin>
   <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
   <link rel="preconnect" href="https://pagead2.googlesyndication.com" crossorigin>
+  <link rel="preconnect" href="https://googleads.g.doubleclick.net" crossorigin>
 
 
 <!-- Hreflang (static full set) -->
@@ -70,7 +71,7 @@
 </script>
 
   <!-- Mammoth.js (DOCX) -->
-  <script src="https://unpkg.com/mammoth@1.6.0/mammoth.browser.min.js"></script>
+  <script defer src="https://unpkg.com/mammoth@1.6.0/mammoth.browser.min.js"></script>
 
   <style>
     :root { --bg:#f7f9fc; --card:#fff; --ink:#0f172a; --muted:#475569; --accent:#2563eb; --ok:#16a34a; --warn:#b45309; --br:14px; --shadow:0 10px 30px rgba(2,6,23,.08); }

--- a/hi/index.html
+++ b/hi/index.html
@@ -21,6 +21,7 @@
   <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin>
   <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
   <link rel="preconnect" href="https://pagead2.googlesyndication.com" crossorigin>
+  <link rel="preconnect" href="https://googleads.g.doubleclick.net" crossorigin>
 
 
 <!-- Hreflang (static full set) -->
@@ -70,7 +71,7 @@
 </script>
 
   <!-- Mammoth.js (DOCX) -->
-  <script src="https://unpkg.com/mammoth@1.6.0/mammoth.browser.min.js"></script>
+  <script defer src="https://unpkg.com/mammoth@1.6.0/mammoth.browser.min.js"></script>
 
   <style>
     :root { --bg:#f7f9fc; --card:#fff; --ink:#0f172a; --muted:#475569; --accent:#2563eb; --ok:#16a34a; --warn:#b45309; --br:14px; --shadow:0 10px 30px rgba(2,6,23,.08); }

--- a/index.html
+++ b/index.html
@@ -21,6 +21,7 @@
   <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin>
   <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
   <link rel="preconnect" href="https://pagead2.googlesyndication.com" crossorigin>
+  <link rel="preconnect" href="https://googleads.g.doubleclick.net" crossorigin>
 
 
 <!-- Hreflang (static full set) -->
@@ -70,7 +71,7 @@
 </script>
 
   <!-- Mammoth.js (DOCX) -->
-  <script src="https://unpkg.com/mammoth@1.6.0/mammoth.browser.min.js"></script>
+  <script defer src="https://unpkg.com/mammoth@1.6.0/mammoth.browser.min.js"></script>
 
   <style>
     :root { --bg:#f7f9fc; --card:#fff; --ink:#0f172a; --muted:#475569; --accent:#2563eb; --ok:#16a34a; --warn:#b45309; --br:14px; --shadow:0 10px 30px rgba(2,6,23,.08); }

--- a/it/index.html
+++ b/it/index.html
@@ -21,6 +21,7 @@
   <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin>
   <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
   <link rel="preconnect" href="https://pagead2.googlesyndication.com" crossorigin>
+  <link rel="preconnect" href="https://googleads.g.doubleclick.net" crossorigin>
 
 
 <!-- Hreflang (static full set) -->
@@ -70,7 +71,7 @@
 </script>
 
   <!-- Mammoth.js (DOCX) -->
-  <script src="https://unpkg.com/mammoth@1.6.0/mammoth.browser.min.js"></script>
+  <script defer src="https://unpkg.com/mammoth@1.6.0/mammoth.browser.min.js"></script>
 
   <style>
     :root { --bg:#f7f9fc; --card:#fff; --ink:#0f172a; --muted:#475569; --accent:#2563eb; --ok:#16a34a; --warn:#b45309; --br:14px; --shadow:0 10px 30px rgba(2,6,23,.08); }

--- a/pt/index.html
+++ b/pt/index.html
@@ -21,6 +21,7 @@
   <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin>
   <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
   <link rel="preconnect" href="https://pagead2.googlesyndication.com" crossorigin>
+  <link rel="preconnect" href="https://googleads.g.doubleclick.net" crossorigin>
 
 
 <!-- Hreflang (static full set) -->
@@ -70,7 +71,7 @@
 </script>
 
   <!-- Mammoth.js (DOCX) -->
-  <script src="https://unpkg.com/mammoth@1.6.0/mammoth.browser.min.js"></script>
+  <script defer src="https://unpkg.com/mammoth@1.6.0/mammoth.browser.min.js"></script>
 
   <style>
     :root { --bg:#f7f9fc; --card:#fff; --ink:#0f172a; --muted:#475569; --accent:#2563eb; --ok:#16a34a; --warn:#b45309; --br:14px; --shadow:0 10px 30px rgba(2,6,23,.08); }

--- a/ru/index.html
+++ b/ru/index.html
@@ -21,6 +21,7 @@
   <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin>
   <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
   <link rel="preconnect" href="https://pagead2.googlesyndication.com" crossorigin>
+  <link rel="preconnect" href="https://googleads.g.doubleclick.net" crossorigin>
 
 
 <!-- Hreflang (static full set) -->
@@ -70,7 +71,7 @@
 </script>
 
   <!-- Mammoth.js (DOCX) -->
-  <script src="https://unpkg.com/mammoth@1.6.0/mammoth.browser.min.js"></script>
+  <script defer src="https://unpkg.com/mammoth@1.6.0/mammoth.browser.min.js"></script>
 
   <style>
     :root { --bg:#f7f9fc; --card:#fff; --ink:#0f172a; --muted:#475569; --accent:#2563eb; --ok:#16a34a; --warn:#b45309; --br:14px; --shadow:0 10px 30px rgba(2,6,23,.08); }

--- a/zh/index.html
+++ b/zh/index.html
@@ -21,6 +21,7 @@
   <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin>
   <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
   <link rel="preconnect" href="https://pagead2.googlesyndication.com" crossorigin>
+  <link rel="preconnect" href="https://googleads.g.doubleclick.net" crossorigin>
 
 
 <!-- Hreflang (static full set) -->
@@ -70,7 +71,7 @@
 </script>
 
   <!-- Mammoth.js (DOCX) -->
-  <script src="https://unpkg.com/mammoth@1.6.0/mammoth.browser.min.js"></script>
+  <script defer src="https://unpkg.com/mammoth@1.6.0/mammoth.browser.min.js"></script>
 
   <style>
     :root { --bg:#f7f9fc; --card:#fff; --ink:#0f172a; --muted:#475569; --accent:#2563eb; --ok:#16a34a; --warn:#b45309; --br:14px; --shadow:0 10px 30px rgba(2,6,23,.08); }


### PR DESCRIPTION
## Summary
- defer Mammoth.js loading across index pages
- preconnect to additional AdSense domain for faster ad fetch

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bec7762e488329bcfe27c50d07c899