### PR TITLE
fix(vercel): add slash variants for topic rewrites to match trailingSlash

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -43,7 +43,11 @@
     { "source": "/explain/bill",       "destination": "/?topic=bill" },
     { "source": "/explain/contract",   "destination": "/?topic=contract" },
     { "source": "/fr/expliquer/facture","destination": "/fr/?topic=facture" },
-    { "source": "/fr/expliquer/contrat","destination": "/fr/?topic=contrat" }
+    { "source": "/fr/expliquer/contrat","destination": "/fr/?topic=contrat" },
+    { "source": "/explain/bill/",        "destination": "/?topic=bill" },
+    { "source": "/explain/contract/",    "destination": "/?topic=contract" },
+    { "source": "/fr/expliquer/facture/", "destination": "/fr/?topic=facture" },
+    { "source": "/fr/expliquer/contrat/", "destination": "/fr/?topic=contrat" }
   ],
 
   "headers": [


### PR DESCRIPTION
## Summary
- support trailingSlash for topic URLs by adding slash variants to rewrites

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bed3992ef4832993eac6ffcc30cf0a