### PR TITLE
Normalize internal links & hreflang to trailing slash URLs

### DIFF
--- a/fr/index.html
+++ b/fr/index.html
@@ -272,8 +272,8 @@ main.no-privacy {
         <p id="hero-sub">Free, private, multilingual. Not legal advice.</p>
       </div>
       <nav class="topics" id="topics-fr" style="margin:10px 0;">
-        <a href="/fr/expliquer/facture">Expliquer une facture</a> ·
-        <a href="/fr/expliquer/contrat">Expliquer un contrat</a>
+        <a href="/fr/expliquer/facture/">Expliquer une facture</a> ·
+        <a href="/fr/expliquer/contrat/">Expliquer un contrat</a>
       </nav>
       <!-- File input (customized & translatable) -->
 <div class="file-row">
@@ -963,7 +963,7 @@ async function ensureHeavyLibs(){
   var lang=(document.documentElement.lang||'fr').toLowerCase();
   var CFG={ fr:{
     facture:{
-      path:"/fr/expliquer/facture",
+      path:"/fr/expliquer/facture/",
       title:"Expliquer une facture — Gratuit & privé | DocuMate",
       desc:"Téléversez votre facture ou collez le texte. Explications en langage simple. Multi-langue.",
       h1:"Expliquer une facture en langage simple",
@@ -972,13 +972,13 @@ async function ensureHeavyLibs(){
         ["Est-ce privé ?","Nous ne stockons pas vos documents ; le transfert est chiffré. Vous pouvez enregistrer localement."]
       ],
       alternates:[
-        ["en","https://documate.work/explain/bill"],
-        ["fr","https://documate.work/fr/expliquer/facture"],
-        ["x-default","https://documate.work/fr/expliquer/facture"]
+        ["en","https://documate.work/explain/bill/"],
+        ["fr","https://documate.work/fr/expliquer/facture/"],
+        ["x-default","https://documate.work/fr/expliquer/facture/"]
       ]
     },
     contrat:{
-      path:"/fr/expliquer/contrat",
+      path:"/fr/expliquer/contrat/",
       title:"Expliquer un contrat — Langage simple | DocuMate",
       desc:"Collez ou importez un contrat et obtenez une explication en langage simple. Pas un conseil juridique.",
       h1:"Expliquer un contrat en langage simple",
@@ -986,9 +986,9 @@ async function ensureHeavyLibs(){
         ["Pouvez-vous expliquer une clause ?","Oui, posez une question sur un passage précis ; nous le résumons clairement."]
       ],
       alternates:[
-        ["en","https://documate.work/explain/contract"],
-        ["fr","https://documate.work/fr/expliquer/contrat"],
-        ["x-default","https://documate.work/fr/expliquer/contrat"]
+        ["en","https://documate.work/explain/contract/"],
+        ["fr","https://documate.work/fr/expliquer/contrat/"],
+        ["x-default","https://documate.work/fr/expliquer/contrat/"]
       ]
     }
   }};

--- a/index.html
+++ b/index.html
@@ -365,8 +365,8 @@ main.no-privacy {
     <p class="legal" id="seo-text">Contracts, rental agreements, utility bills, bank letters, insurance terms, general conditions, and more.</p>
   </div>
   <nav class="topics" id="topics-en" style="margin:10px 0;">
-    <a href="/explain/bill">Explain a bill</a> ·
-    <a href="/explain/contract">Explain a contract</a>
+    <a href="/explain/bill/">Explain a bill</a> ·
+    <a href="/explain/contract/">Explain a contract</a>
   </nav>
 
   <section class="card" id="faq-card">
@@ -964,7 +964,7 @@ async function ensureHeavyLibs(){
   var CFG = {
     en: {
       bill: {
-        path: "/explain/bill",
+        path: "/explain/bill/",
         title: "Explain a Bill Online — Free & Private | DocuMate",
         desc:  "Upload your bill or paste text. DocuMate explains it in plain English. Free, private, multilingual.",
         h1:    "Explain a bill in plain English",
@@ -973,13 +973,13 @@ async function ensureHeavyLibs(){
           ["Is it private?","We don’t store your documents; transfer is encrypted. You can save locally if you wish."]
         ],
         alternates: [
-          ["en","https://documate.work/explain/bill"],
-          ["fr","https://documate.work/fr/expliquer/facture"],
-          ["x-default","https://documate.work/explain/bill"]
+          ["en","https://documate.work/explain/bill/"],
+          ["fr","https://documate.work/fr/expliquer/facture/"],
+          ["x-default","https://documate.work/explain/bill/"]
         ]
       },
       contract: {
-        path: "/explain/contract",
+        path: "/explain/contract/",
         title: "Explain a Contract — Plain English | DocuMate",
         desc:  "Paste or upload a contract and get a plain-language explanation. Not legal advice.",
         h1:    "Explain a contract in plain English",
@@ -987,9 +987,9 @@ async function ensureHeavyLibs(){
           ["Can DocuMate explain clauses?","Yes. Ask about any passage; we’ll summarize and clarify it in plain language."]
         ],
         alternates: [
-          ["en","https://documate.work/explain/contract"],
-          ["fr","https://documate.work/fr/expliquer/contrat"],
-          ["x-default","https://documate.work/explain/contract"]
+          ["en","https://documate.work/explain/contract/"],
+          ["fr","https://documate.work/fr/expliquer/contrat/"],
+          ["x-default","https://documate.work/explain/contract/"]
         ]
       }
     }


### PR DESCRIPTION
## Summary
- ensure topic links use canonical trailing-slash URLs
- update hreflang alternate URLs for bill and contract pages

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bee35e8704832994f1ae6dfa0fde62