### PR TITLE
feat: add HTML redirects for bill and contract explanations

### DIFF
--- a/public/explain/bill/index.html
+++ b/public/explain/bill/index.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<!-- SPDX-License-Identifier: LicenseRef-SA-NC-1.0 -->
+<html lang="en"><head>
+  <meta charset="utf-8">
+  <link rel="canonical" href="https://documate.work/explain/bill/">
+  <meta http-equiv="refresh" content="0; url=/index.html?topic=bill">
+  <title>Documate — Bill</title>
+</head><body></body></html>

--- a/public/explain/contract/index.html
+++ b/public/explain/contract/index.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<!-- SPDX-License-Identifier: LicenseRef-SA-NC-1.0 -->
+<html lang="en"><head>
+  <meta charset="utf-8">
+  <link rel="canonical" href="https://documate.work/explain/contract/">
+  <meta http-equiv="refresh" content="0; url=/index.html?topic=contract">
+  <title>Documate — Contract</title>
+</head><body></body></html>

--- a/public/fr/expliquer/contrat/index.html
+++ b/public/fr/expliquer/contrat/index.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<!-- SPDX-License-Identifier: LicenseRef-SA-NC-1.0 -->
+<html lang="fr"><head>
+  <meta charset="utf-8">
+  <link rel="canonical" href="https://documate.work/fr/expliquer/contrat/">
+  <meta http-equiv="refresh" content="0; url=/fr/index.html?topic=contract">
+  <title>Documate — Contrat</title>
+</head><body></body></html>

--- a/public/fr/expliquer/facture/index.html
+++ b/public/fr/expliquer/facture/index.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<!-- SPDX-License-Identifier: LicenseRef-SA-NC-1.0 -->
+<html lang="fr"><head>
+  <meta charset="utf-8">
+  <link rel="canonical" href="https://documate.work/fr/expliquer/facture/">
+  <meta http-equiv="refresh" content="0; url=/fr/index.html?topic=bill">
+  <title>Documate — Facture</title>
+</head><body></body></html>


### PR DESCRIPTION
## Summary
- add English redirects for bill and contract explanations
- add French redirects for facture and contrat explanations

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c008d07eac83299803f186efdcebad