### PR TITLE
fix: update canonical bootstrap and vercel config

### DIFF
--- a/fr/index.html
+++ b/fr/index.html
@@ -3,64 +3,34 @@
 <html lang="fr">
 <head>
   <meta charset="utf-8" />
-  <link id="canonical-link" rel="canonical" href="https://documate.work/fr/">
+  <link rel="canonical" id="canonical-link" href="https://documate.work/fr/">
+  <meta property="og:url" content="https://documate.work/fr/">
+  <meta name="twitter:url" content="https://documate.work/fr/">
   <script id="canonical-bootstrap">
 (function () {
   var ORIGIN = location.origin;
   var path = (location.pathname.replace(/\/+$/, '/') || '/');
   var lang = path.startsWith('/fr/') ? 'fr' : 'en';
-
-  // Déduction du topic key (bill|contract) depuis ?topic=... ou depuis le pathname "propre"
   var params = new URLSearchParams(location.search);
-  function keyFromQuery() {
-    var t = (params.get('topic') || '').toLowerCase();
-    return (t === 'bill' || t === 'contract') ? t : null;
-  }
-  function keyFromPath() {
+  function keyFromQuery(){var t=(params.get('topic')||'').toLowerCase();return (t==='bill'||t==='contract')?t:null;}
+  function keyFromPath(){
     var m = path.match(/^\/explain\/([^/]+)\/$/);
-    if (m) {
-      var en = m[1].toLowerCase();
-      if (en === 'bill' || en === 'contract') return en;
-    }
+    if (m){var en=m[1].toLowerCase(); if (en==='bill'||en==='contract') return en;}
     m = path.match(/^\/fr\/expliquer\/([^/]+)\/$/);
-    if (m) {
-      var fr = m[1].toLowerCase();
-      if (fr === 'facture') return 'bill';
-      if (fr === 'contrat') return 'contract';
-    }
+    if (m){var fr=m[1].toLowerCase(); if (fr==='facture') return 'bill'; if (fr==='contrat') return 'contract';}
     return null;
   }
   var key = keyFromQuery() || keyFromPath();
-
-  // Construit l'URL canonique "jolie" à partir de la clé
-  function canonicalHref(lang, key) {
-    if (!key) return ORIGIN + (lang === 'fr' ? '/fr/' : '/');
-    if (lang === 'fr') {
-      var frSlug = (key === 'bill') ? 'facture' : 'contrat';
-      return ORIGIN + '/fr/expliquer/' + frSlug + '/';
-    } else {
-      return ORIGIN + '/explain/' + key + '/';
-    }
-  }
-  var canonicalAbs = canonicalHref(lang, key);
-
-  // Met à jour/insère la canonical immédiatement
-  var link = document.getElementById('canonical-link') || document.querySelector('link[rel="canonical"]');
-  if (!link) {
-    link = document.createElement('link');
-    link.setAttribute('rel', 'canonical');
-    link.id = 'canonical-link';
-    document.head.appendChild(link);
-  }
-  link.setAttribute('href', canonicalAbs);
-
-  // Aligne og:url et twitter:url si présents
-  var og = document.querySelector('meta[property="og:url"]');
-  if (og) og.setAttribute('content', canonicalAbs);
-  var tw = document.querySelector('meta[name="twitter:url"]');
-  if (tw) tw.setAttribute('content', canonicalAbs);
-
-  // Expose (optionnel)
+  var canonicalAbs = (function(){
+    if (!key) return ORIGIN + (lang==='fr'?'/fr/':'/');
+    if (lang==='fr'){var frSlug=(key==='bill')?'facture':'contrat'; return ORIGIN+'/fr/expliquer/'+frSlug+'/';}
+    return ORIGIN+'/explain/'+key+'/';
+  })();
+  var link=document.getElementById('canonical-link')||document.querySelector('link[rel="canonical"]');
+  if(!link){link=document.createElement('link');link.rel='canonical';link.id='canonical-link';document.head.appendChild(link);}
+  link.href=canonicalAbs;
+  var og=document.querySelector('meta[property="og:url"]'); if(og) og.setAttribute('content', canonicalAbs);
+  var tw=document.querySelector('meta[name="twitter:url"]'); if(tw) tw.setAttribute('content', canonicalAbs);
   window.__DOCUMATE_TOPIC__ = key || null;
   window.__DOCUMATE_CANONICAL__ = canonicalAbs;
 })();

--- a/index.html
+++ b/index.html
@@ -3,64 +3,34 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
-  <link id="canonical-link" rel="canonical" href="https://documate.work/">
+  <link rel="canonical" id="canonical-link" href="https://documate.work/">
+  <meta property="og:url" content="https://documate.work/">
+  <meta name="twitter:url" content="https://documate.work/">
   <script id="canonical-bootstrap">
 (function () {
   var ORIGIN = location.origin;
   var path = (location.pathname.replace(/\/+$/, '/') || '/');
   var lang = path.startsWith('/fr/') ? 'fr' : 'en';
-
-  // Déduction du topic key (bill|contract) depuis ?topic=... ou depuis le pathname "propre"
   var params = new URLSearchParams(location.search);
-  function keyFromQuery() {
-    var t = (params.get('topic') || '').toLowerCase();
-    return (t === 'bill' || t === 'contract') ? t : null;
-  }
-  function keyFromPath() {
+  function keyFromQuery(){var t=(params.get('topic')||'').toLowerCase();return (t==='bill'||t==='contract')?t:null;}
+  function keyFromPath(){
     var m = path.match(/^\/explain\/([^/]+)\/$/);
-    if (m) {
-      var en = m[1].toLowerCase();
-      if (en === 'bill' || en === 'contract') return en;
-    }
+    if (m){var en=m[1].toLowerCase(); if (en==='bill'||en==='contract') return en;}
     m = path.match(/^\/fr\/expliquer\/([^/]+)\/$/);
-    if (m) {
-      var fr = m[1].toLowerCase();
-      if (fr === 'facture') return 'bill';
-      if (fr === 'contrat') return 'contract';
-    }
+    if (m){var fr=m[1].toLowerCase(); if (fr==='facture') return 'bill'; if (fr==='contrat') return 'contract';}
     return null;
   }
   var key = keyFromQuery() || keyFromPath();
-
-  // Construit l'URL canonique "jolie" à partir de la clé
-  function canonicalHref(lang, key) {
-    if (!key) return ORIGIN + (lang === 'fr' ? '/fr/' : '/');
-    if (lang === 'fr') {
-      var frSlug = (key === 'bill') ? 'facture' : 'contrat';
-      return ORIGIN + '/fr/expliquer/' + frSlug + '/';
-    } else {
-      return ORIGIN + '/explain/' + key + '/';
-    }
-  }
-  var canonicalAbs = canonicalHref(lang, key);
-
-  // Met à jour/insère la canonical immédiatement
-  var link = document.getElementById('canonical-link') || document.querySelector('link[rel="canonical"]');
-  if (!link) {
-    link = document.createElement('link');
-    link.setAttribute('rel', 'canonical');
-    link.id = 'canonical-link';
-    document.head.appendChild(link);
-  }
-  link.setAttribute('href', canonicalAbs);
-
-  // Aligne og:url et twitter:url si présents
-  var og = document.querySelector('meta[property="og:url"]');
-  if (og) og.setAttribute('content', canonicalAbs);
-  var tw = document.querySelector('meta[name="twitter:url"]');
-  if (tw) tw.setAttribute('content', canonicalAbs);
-
-  // Expose (optionnel)
+  var canonicalAbs = (function(){
+    if (!key) return ORIGIN + (lang==='fr'?'/fr/':'/');
+    if (lang==='fr'){var frSlug=(key==='bill')?'facture':'contrat'; return ORIGIN+'/fr/expliquer/'+frSlug+'/';}
+    return ORIGIN+'/explain/'+key+'/';
+  })();
+  var link=document.getElementById('canonical-link')||document.querySelector('link[rel="canonical"]');
+  if(!link){link=document.createElement('link');link.rel='canonical';link.id='canonical-link';document.head.appendChild(link);}
+  link.href=canonicalAbs;
+  var og=document.querySelector('meta[property="og:url"]'); if(og) og.setAttribute('content', canonicalAbs);
+  var tw=document.querySelector('meta[name="twitter:url"]'); if(tw) tw.setAttribute('content', canonicalAbs);
   window.__DOCUMATE_TOPIC__ = key || null;
   window.__DOCUMATE_CANONICAL__ = canonicalAbs;
 })();

--- a/vercel.json
+++ b/vercel.json
@@ -18,10 +18,12 @@
 
     { "source": "/(.*\\.(?:js|css|png|jpg|jpeg|gif|svg|webp|ico|json|txt|woff|woff2|map))", "destination": "/$1" },
 
+    { "source": "/", "destination": "/index.html" },
+    { "source": "/fr/", "destination": "/fr/index.html" },
+
     { "source": "/explain/:topic/", "destination": "/index.html?topic=:topic" },
     { "source": "/fr/expliquer/:topic/", "destination": "/fr/index.html?topic=:topic" },
 
-    { "source": "/fr/", "destination": "/fr/index.html" },
     { "source": "/(.*)", "destination": "/" }
   ],
   "headers": [


### PR DESCRIPTION
## Summary
- add rewrites for `/` and `/fr/` and topic pages in Vercel config
- ensure canonical and social URL metadata with bootstrap script in root and French index pages

## Testing
- `npm test` (fails: Missing script)
- `curl -I https://documate.work/` *(fails: CONNECT tunnel failed, response 403)*
- `curl -s https://documate.work/ | grep -i canonical` *(no output)
- `curl -I https://documate.work/explain/bill/` *(fails: CONNECT tunnel failed, response 403)*
- `curl -s https://documate.work/explain/bill/ | grep -i canonical` *(no output)*

------
https://chatgpt.com/codex/tasks/task_e_68c00a4ce9f88329845a9702ae01e620