### PR TITLE
chore: replace canonical bootstrap scripts

### DIFF
--- a/fr/index.html
+++ b/fr/index.html
@@ -12,25 +12,33 @@
   var path = (location.pathname.replace(/\/+$/, '/') || '/');
   var lang = path.startsWith('/fr/') ? 'fr' : 'en';
   var params = new URLSearchParams(location.search);
-  function keyFromQuery(){var t=(params.get('topic')||'').toLowerCase();return (t==='bill'||t==='contract')?t:null;}
-  function keyFromPath(){
+
+  function keyFromQuery() {
+    var t = (params.get('topic') || '').toLowerCase();
+    return (t === 'bill' || t === 'contract') ? t : null;
+  }
+  function keyFromPath() {
     var m = path.match(/^\/explain\/([^/]+)\/$/);
-    if (m){var en=m[1].toLowerCase(); if (en==='bill'||en==='contract') return en;}
+    if (m) { var en = m[1].toLowerCase(); if (en === 'bill' || en === 'contract') return en; }
     m = path.match(/^\/fr\/expliquer\/([^/]+)\/$/);
-    if (m){var fr=m[1].toLowerCase(); if (fr==='facture') return 'bill'; if (fr==='contrat') return 'contract';}
+    if (m) { var fr = m[1].toLowerCase(); if (fr === 'facture') return 'bill'; if (fr === 'contrat') return 'contract'; }
     return null;
   }
+
   var key = keyFromQuery() || keyFromPath();
   var canonicalAbs = (function(){
-    if (!key) return ORIGIN + (lang==='fr'?'/fr/':'/');
-    if (lang==='fr'){var frSlug=(key==='bill')?'facture':'contrat'; return ORIGIN+'/fr/expliquer/'+frSlug+'/';}
-    return ORIGIN+'/explain/'+key+'/';
+    if (!key) return ORIGIN + (lang === 'fr' ? '/fr/' : '/');
+    if (lang === 'fr') return ORIGIN + '/fr/expliquer/' + (key === 'bill' ? 'facture' : 'contrat') + '/';
+    return ORIGIN + '/explain/' + key + '/';
   })();
-  var link=document.getElementById('canonical-link')||document.querySelector('link[rel="canonical"]');
-  if(!link){link=document.createElement('link');link.rel='canonical';link.id='canonical-link';document.head.appendChild(link);}
-  link.href=canonicalAbs;
-  var og=document.querySelector('meta[property="og:url"]'); if(og) og.setAttribute('content', canonicalAbs);
-  var tw=document.querySelector('meta[name="twitter:url"]'); if(tw) tw.setAttribute('content', canonicalAbs);
+
+  var link = document.getElementById('canonical-link') || document.querySelector('link[rel="canonical"]');
+  if (!link) { link = document.createElement('link'); link.rel = 'canonical'; link.id='canonical-link'; document.head.appendChild(link); }
+  link.href = canonicalAbs;
+
+  var og = document.querySelector('meta[property="og:url"]'); if (og) og.setAttribute('content', canonicalAbs);
+  var tw = document.querySelector('meta[name="twitter:url"]'); if (tw) tw.setAttribute('content', canonicalAbs);
+
   window.__DOCUMATE_TOPIC__ = key || null;
   window.__DOCUMATE_CANONICAL__ = canonicalAbs;
 })();

--- a/index.html
+++ b/index.html
@@ -12,25 +12,33 @@
   var path = (location.pathname.replace(/\/+$/, '/') || '/');
   var lang = path.startsWith('/fr/') ? 'fr' : 'en';
   var params = new URLSearchParams(location.search);
-  function keyFromQuery(){var t=(params.get('topic')||'').toLowerCase();return (t==='bill'||t==='contract')?t:null;}
-  function keyFromPath(){
+
+  function keyFromQuery() {
+    var t = (params.get('topic') || '').toLowerCase();
+    return (t === 'bill' || t === 'contract') ? t : null;
+  }
+  function keyFromPath() {
     var m = path.match(/^\/explain\/([^/]+)\/$/);
-    if (m){var en=m[1].toLowerCase(); if (en==='bill'||en==='contract') return en;}
+    if (m) { var en = m[1].toLowerCase(); if (en === 'bill' || en === 'contract') return en; }
     m = path.match(/^\/fr\/expliquer\/([^/]+)\/$/);
-    if (m){var fr=m[1].toLowerCase(); if (fr==='facture') return 'bill'; if (fr==='contrat') return 'contract';}
+    if (m) { var fr = m[1].toLowerCase(); if (fr === 'facture') return 'bill'; if (fr === 'contrat') return 'contract'; }
     return null;
   }
+
   var key = keyFromQuery() || keyFromPath();
   var canonicalAbs = (function(){
-    if (!key) return ORIGIN + (lang==='fr'?'/fr/':'/');
-    if (lang==='fr'){var frSlug=(key==='bill')?'facture':'contrat'; return ORIGIN+'/fr/expliquer/'+frSlug+'/';}
-    return ORIGIN+'/explain/'+key+'/';
+    if (!key) return ORIGIN + (lang === 'fr' ? '/fr/' : '/');
+    if (lang === 'fr') return ORIGIN + '/fr/expliquer/' + (key === 'bill' ? 'facture' : 'contrat') + '/';
+    return ORIGIN + '/explain/' + key + '/';
   })();
-  var link=document.getElementById('canonical-link')||document.querySelector('link[rel="canonical"]');
-  if(!link){link=document.createElement('link');link.rel='canonical';link.id='canonical-link';document.head.appendChild(link);}
-  link.href=canonicalAbs;
-  var og=document.querySelector('meta[property="og:url"]'); if(og) og.setAttribute('content', canonicalAbs);
-  var tw=document.querySelector('meta[name="twitter:url"]'); if(tw) tw.setAttribute('content', canonicalAbs);
+
+  var link = document.getElementById('canonical-link') || document.querySelector('link[rel="canonical"]');
+  if (!link) { link = document.createElement('link'); link.rel = 'canonical'; link.id='canonical-link'; document.head.appendChild(link); }
+  link.href = canonicalAbs;
+
+  var og = document.querySelector('meta[property="og:url"]'); if (og) og.setAttribute('content', canonicalAbs);
+  var tw = document.querySelector('meta[name="twitter:url"]'); if (tw) tw.setAttribute('content', canonicalAbs);
+
   window.__DOCUMATE_TOPIC__ = key || null;
   window.__DOCUMATE_CANONICAL__ = canonicalAbs;
 })();


### PR DESCRIPTION
## Summary
- replace canonical bootstrap script on English and French homepages

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c015460f5883299642406d997be932