### PR TITLE
Add SEO mini-pages for bill and contract

### DIFF
--- a/explain/bill/index.html
+++ b/explain/bill/index.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<!-- SPDX-License-Identifier: LicenseRef-SA-NC-1.0 -->
+<html lang="en"><head>
+  <meta charset="utf-8">
+  <link rel="canonical" href="https://documate.work/explain/bill/">
+  <meta http-equiv="refresh" content="0; url=/index.html?topic=bill">
+  <title>Documate — Bill</title>
+</head><body></body></html>

--- a/explain/contract/index.html
+++ b/explain/contract/index.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<!-- SPDX-License-Identifier: LicenseRef-SA-NC-1.0 -->
+<html lang="en"><head>
+  <meta charset="utf-8">
+  <link rel="canonical" href="https://documate.work/explain/contract/">
+  <meta http-equiv="refresh" content="0; url=/index.html?topic=contract">
+  <title>Documate — Contract</title>
+</head><body></body></html>

--- a/fr/expliquer/contrat/index.html
+++ b/fr/expliquer/contrat/index.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<!-- SPDX-License-Identifier: LicenseRef-SA-NC-1.0 -->
+<html lang="fr"><head>
+  <meta charset="utf-8">
+  <link rel="canonical" href="https://documate.work/fr/expliquer/contrat/">
+  <meta http-equiv="refresh" content="0; url=/fr/index.html?topic=contract">
+  <title>Documate — Contrat</title>
+</head><body></body></html>

--- a/fr/expliquer/facture/index.html
+++ b/fr/expliquer/facture/index.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<!-- SPDX-License-Identifier: LicenseRef-SA-NC-1.0 -->
+<html lang="fr"><head>
+  <meta charset="utf-8">
+  <link rel="canonical" href="https://documate.work/fr/expliquer/facture/">
+  <meta http-equiv="refresh" content="0; url=/fr/index.html?topic=bill">
+  <title>Documate — Facture</title>
+</head><body></body></html>


### PR DESCRIPTION
## Summary
- add canonical HTML redirect pages for Bill and Contract topics in English and French

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c01b3590f88329ad35829c556db2ef