### PR TITLE
chore: canonical hardening for home pages

### DIFF
--- a/fr/index.html
+++ b/fr/index.html
@@ -3,31 +3,53 @@
 <html lang="fr">
 <head>
   <meta charset="utf-8" />
-  <link rel="canonical" id="canonical-link" href="https://documate.work/fr/">
+  <!-- Canonical hardening START -->
+  <script id="canonical-bootstrap">
+(function () {
+  var ORIGIN = location.origin;
+  var PATH = (location.pathname.replace(/\/+$/, '/') || '/');
+  var LANG = PATH.startsWith('/fr/') ? 'fr' : 'en';
+  var params = new URLSearchParams(location.search);
+  function keyFromQuery(){ var t=(params.get('topic')||'').toLowerCase(); return (t==='bill'||t==='contract')?t:null; }
+  function keyFromPath(){
+    var m = PATH.match(/^\/explain\/([^/]+)\/$/); if (m){ var en=m[1].toLowerCase(); if (en==='bill'||en==='contract') return en; }
+    m = PATH.match(/^\/fr\/expliquer\/([^/]+)\/$/); if (m){ var fr=m[1].toLowerCase(); if (fr==='facture') return 'bill'; if (fr==='contrat') return 'contract'; }
+    return null;
+  }
+  var key = keyFromQuery() || keyFromPath();
+  var canonicalAbs = !key
+    ? ORIGIN + (LANG==='fr'?'/fr/':'/')
+    : (LANG==='fr'
+       ? ORIGIN + '/fr/expliquer/' + (key==='bill'?'facture':'contrat') + '/'
+       : ORIGIN + '/explain/' + key + '/');
+
+  // 1) Retire toutes les canonical existantes
+  var olds = Array.prototype.slice.call(document.querySelectorAll('link[rel="canonical"]'));
+  for (var i=0; i<olds.length; i++) { olds[i].parentNode.removeChild(olds[i]); }
+
+  // 2) Crée UNE seule canonical, tout en haut du <head>
+  var link = document.createElement('link');
+  link.rel = 'canonical';
+  link.id = 'canonical-link';
+  link.href = canonicalAbs;
+  document.head.insertBefore(link, document.head.firstChild);
+
+  // 3) Aligne og:url et twitter:url
+  var og = document.querySelector('meta[property="og:url"]');
+  if (!og) { og = document.createElement('meta'); og.setAttribute('property','og:url'); document.head.appendChild(og); }
+  og.setAttribute('content', canonicalAbs);
+
+  var tw = document.querySelector('meta[name="twitter:url"]');
+  if (!tw) { tw = document.createElement('meta'); tw.setAttribute('name','twitter:url'); document.head.appendChild(tw); }
+  tw.setAttribute('content', canonicalAbs);
+
+  window.__DOCUMATE_TOPIC__ = key || null;
+  window.__DOCUMATE_CANONICAL__ = canonicalAbs;
+})();
+  </script>
+  <!-- Canonical hardening END -->
   <meta property="og:url" content="https://documate.work/fr/">
   <meta name="twitter:url" content="https://documate.work/fr/">
-  <script id="canonical-bootstrap">
-  (function () {
-    var ORIGIN = location.origin;
-    var path = (location.pathname.replace(/\/+$/, '/') || '/');
-    var lang = path.startsWith('/fr/') ? 'fr' : 'en';
-    var params = new URLSearchParams(location.search);
-    function keyFromQuery(){var t=(params.get('topic')||'').toLowerCase();return (t==='bill'||t==='contract')?t:null;}
-    function keyFromPath(){
-      var m=path.match(/^\/explain\/([^/]+)\/$/); if(m){var en=m[1].toLowerCase(); if(en==='bill'||en==='contract') return en;}
-      m=path.match(/^\/fr\/expliquer\/([^/]+)\/$/); if(m){var fr=m[1].toLowerCase(); if(fr==='facture') return 'bill'; if(fr==='contrat') return 'contract';}
-      return null;
-    }
-    var key=keyFromQuery()||keyFromPath();
-    var canonicalAbs=!key?ORIGIN+(lang==='fr'?'/fr/':'/'):(lang==='fr'?ORIGIN+'/fr/expliquer/'+(key==='bill'?'facture':'contrat')+'/':ORIGIN+'/explain/'+key+'/');
-    var link=document.getElementById('canonical-link')||document.querySelector('link[rel="canonical"]');
-    if(!link){link=document.createElement('link');link.rel='canonical';link.id='canonical-link';document.head.appendChild(link);}
-    link.href=canonicalAbs;
-    var og=document.querySelector('meta[property="og:url"]'); if(og) og.setAttribute('content', canonicalAbs);
-    var tw=document.querySelector('meta[name="twitter:url"]'); if(tw) tw.setAttribute('content', canonicalAbs);
-    window.__DOCUMATE_TOPIC__=key||null; window.__DOCUMATE_CANONICAL__=canonicalAbs;
-  })();
-  </script>
   <meta name="robots" content="index,follow">
   <meta name="viewport" content="width=device-width, initial-scale=1" />
 

--- a/index.html
+++ b/index.html
@@ -3,31 +3,53 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
-  <link rel="canonical" id="canonical-link" href="https://documate.work/">
+  <!-- Canonical hardening START -->
+  <script id="canonical-bootstrap">
+(function () {
+  var ORIGIN = location.origin;
+  var PATH = (location.pathname.replace(/\/+$/, '/') || '/');
+  var LANG = PATH.startsWith('/fr/') ? 'fr' : 'en';
+  var params = new URLSearchParams(location.search);
+  function keyFromQuery(){ var t=(params.get('topic')||'').toLowerCase(); return (t==='bill'||t==='contract')?t:null; }
+  function keyFromPath(){
+    var m = PATH.match(/^\/explain\/([^/]+)\/$/); if (m){ var en=m[1].toLowerCase(); if (en==='bill'||en==='contract') return en; }
+    m = PATH.match(/^\/fr\/expliquer\/([^/]+)\/$/); if (m){ var fr=m[1].toLowerCase(); if (fr==='facture') return 'bill'; if (fr==='contrat') return 'contract'; }
+    return null;
+  }
+  var key = keyFromQuery() || keyFromPath();
+  var canonicalAbs = !key
+    ? ORIGIN + (LANG==='fr'?'/fr/':'/')
+    : (LANG==='fr'
+       ? ORIGIN + '/fr/expliquer/' + (key==='bill'?'facture':'contrat') + '/'
+       : ORIGIN + '/explain/' + key + '/');
+
+  // 1) Retire toutes les canonical existantes
+  var olds = Array.prototype.slice.call(document.querySelectorAll('link[rel="canonical"]'));
+  for (var i=0; i<olds.length; i++) { olds[i].parentNode.removeChild(olds[i]); }
+
+  // 2) Crée UNE seule canonical, tout en haut du <head>
+  var link = document.createElement('link');
+  link.rel = 'canonical';
+  link.id = 'canonical-link';
+  link.href = canonicalAbs;
+  document.head.insertBefore(link, document.head.firstChild);
+
+  // 3) Aligne og:url et twitter:url
+  var og = document.querySelector('meta[property="og:url"]');
+  if (!og) { og = document.createElement('meta'); og.setAttribute('property','og:url'); document.head.appendChild(og); }
+  og.setAttribute('content', canonicalAbs);
+
+  var tw = document.querySelector('meta[name="twitter:url"]');
+  if (!tw) { tw = document.createElement('meta'); tw.setAttribute('name','twitter:url'); document.head.appendChild(tw); }
+  tw.setAttribute('content', canonicalAbs);
+
+  window.__DOCUMATE_TOPIC__ = key || null;
+  window.__DOCUMATE_CANONICAL__ = canonicalAbs;
+})();
+  </script>
+  <!-- Canonical hardening END -->
   <meta property="og:url" content="https://documate.work/">
   <meta name="twitter:url" content="https://documate.work/">
-  <script id="canonical-bootstrap">
-  (function () {
-    var ORIGIN = location.origin;
-    var path = (location.pathname.replace(/\/+$/, '/') || '/');
-    var lang = path.startsWith('/fr/') ? 'fr' : 'en';
-    var params = new URLSearchParams(location.search);
-    function keyFromQuery(){var t=(params.get('topic')||'').toLowerCase();return (t==='bill'||t==='contract')?t:null;}
-    function keyFromPath(){
-      var m=path.match(/^\/explain\/([^/]+)\/$/); if(m){var en=m[1].toLowerCase(); if(en==='bill'||en==='contract') return en;}
-      m=path.match(/^\/fr\/expliquer\/([^/]+)\/$/); if(m){var fr=m[1].toLowerCase(); if(fr==='facture') return 'bill'; if(fr==='contrat') return 'contract';}
-      return null;
-    }
-    var key=keyFromQuery()||keyFromPath();
-    var canonicalAbs=!key?ORIGIN+(lang==='fr'?'/fr/':'/'):(lang==='fr'?ORIGIN+'/fr/expliquer/'+(key==='bill'?'facture':'contrat')+'/':ORIGIN+'/explain/'+key+'/');
-    var link=document.getElementById('canonical-link')||document.querySelector('link[rel="canonical"]');
-    if(!link){link=document.createElement('link');link.rel='canonical';link.id='canonical-link';document.head.appendChild(link);}
-    link.href=canonicalAbs;
-    var og=document.querySelector('meta[property="og:url"]'); if(og) og.setAttribute('content', canonicalAbs);
-    var tw=document.querySelector('meta[name="twitter:url"]'); if(tw) tw.setAttribute('content', canonicalAbs);
-    window.__DOCUMATE_TOPIC__=key||null; window.__DOCUMATE_CANONICAL__=canonicalAbs;
-  })();
-  </script>
   <meta name="robots" content="index,follow">
   <meta name="viewport" content="width=device-width, initial-scale=1" />
 


### PR DESCRIPTION
## Summary
- replace existing canonical logic in English and French home pages with canonical hardening script
- remove pre-set canonical links to prevent duplicates

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c01e9a31e48329a8f91afbbfc26ae5