### PR TITLE
fix: update vercel rewrites to avoid conflicts

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -9,11 +9,22 @@
   ],
 
   "rewrites": [
-    { "source": "/", "destination": "/index.html" },
-    { "source": "/fr/", "destination": "/fr/index.html" },
+    { "source": "/robots.txt", "destination": "/robots.txt" },
+    { "source": "/sitemap.xml", "destination": "/sitemap.xml" },
+    { "source": "/favicon.ico", "destination": "/favicon.ico" },
+    { "source": "/site.webmanifest", "destination": "/site.webmanifest" },
+    { "source": "/icon-192.png", "destination": "/icon-192.png" },
+    { "source": "/icon-512.png", "destination": "/icon-512.png" },
+    { "source": "/apple-touch-icon.png", "destination": "/apple-touch-icon.png" },
+    { "source": "/og.jpg", "destination": "/og.jpg" },
 
-    { "source": "/explain/:topic/", "destination": "/index.html?topic=:topic" },
-    { "source": "/fr/expliquer/:topic/", "destination": "/fr/index.html?topic=:topic" }
+    { "source": "/(.*\\.(?:js|css|png|jpg|jpeg|gif|svg|webp|ico|json|txt|woff|woff2|map))", "destination": "/$1" },
+
+    { "source": "/", "destination": "/index.html" },
+    { "source": "/fr/", "destination": "/fr/index.html" }
+
+    /* ⚠️ PAS de rewrite /explain/:topic/ → index.html ici.
+       On laisse Vercel servir les mini-pages statiques si elles existent. */
   ],
 
   "headers": [


### PR DESCRIPTION
## Summary
- replace `vercel.json` with static asset rewrites and remove dynamic `/explain/:topic/` rewrites

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c03b0e98ec8329b90c03f7810c17af