### PR TITLE
chore: simplify Vercel config

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -9,6 +9,9 @@
   ],
 
   "rewrites": [
+    { "source": "/", "destination": "/index.html" },
+    { "source": "/fr/", "destination": "/fr/index.html" },
+
     { "source": "/robots.txt", "destination": "/robots.txt" },
     { "source": "/sitemap.xml", "destination": "/sitemap.xml" },
     { "source": "/favicon.ico", "destination": "/favicon.ico" },
@@ -18,13 +21,10 @@
     { "source": "/apple-touch-icon.png", "destination": "/apple-touch-icon.png" },
     { "source": "/og.jpg", "destination": "/og.jpg" },
 
-    { "source": "/(.*\\.(?:js|css|png|jpg|jpeg|gif|svg|webp|ico|json|txt|woff|woff2|map))", "destination": "/$1" },
+    { "source": "/(.*\\.(?:js|css|png|jpg|jpeg|gif|svg|webp|ico|json|txt|woff|woff2|map))", "destination": "/$1" }
 
-    { "source": "/", "destination": "/index.html" },
-    { "source": "/fr/", "destination": "/fr/index.html" }
-
-    /* ⚠️ PAS de rewrite /explain/:topic/ → index.html ici.
-       On laisse Vercel servir les mini-pages statiques si elles existent. */
+    /* ⚠️ Pas de rewrite "/explain/:topic/" → index.html.
+       Les pages statiques explain/* et fr/expliquer/* seront donc servies telles quelles. */
   ],
 
   "headers": [


### PR DESCRIPTION
## Summary
- simplify `vercel.json` so pretty URLs remain untouched and static pages are served as-is

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c041ceb068832988f76173c9d402cd